### PR TITLE
Visibility Listener

### DIFF
--- a/CardParts/Classes/CardPartsViewController.swift
+++ b/CardParts/Classes/CardPartsViewController.swift
@@ -41,7 +41,6 @@ open class CardPartsViewController : UIViewController, CardController {
 	
     override open func viewDidLoad() {
         super.viewDidLoad()
-        
     }
 
 	public func setupCardParts(_ cardParts:[CardPartView], forState: CardState = .none) {
@@ -147,6 +146,13 @@ open class CardPartsViewController : UIViewController, CardController {
             }
         }
     }
+}
+
+// extension for defining the visibility delegate
+extension CardPartsViewController: CardVisibilityDelegate {
+    
+    // defines the visilbity of a card
+    open func cardVisibility(percentVisible: CGFloat) {}
 }
 
 extension Reactive where Base: CardPartsViewController {

--- a/CardParts/Classes/CardPartsViewController.swift
+++ b/CardParts/Classes/CardPartsViewController.swift
@@ -34,6 +34,9 @@ open class CardPartsViewController : UIViewController, CardController {
 	}
 	
 	var marginViews: [UIView: (UIView?, UIView?)] = [:]
+    
+    // percent visibility of a card
+    var visibility: CGFloat = -1.0
 	
 	private var cardParts:[CardState : CardStateData] = [:]
 	
@@ -146,13 +149,6 @@ open class CardPartsViewController : UIViewController, CardController {
             }
         }
     }
-}
-
-// extension for defining the visibility delegate
-extension CardPartsViewController: CardVisibilityDelegate {
-    
-    // defines the visilbity of a card
-    open func cardVisibility(percentVisible: CGFloat) {}
 }
 
 extension Reactive where Base: CardPartsViewController {

--- a/CardParts/Classes/CardsViewController.swift
+++ b/CardParts/Classes/CardsViewController.swift
@@ -46,6 +46,9 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
     var cardControllers = [CardInfo]()
 	var bag = DisposeBag()
     
+    // previous scrollview bounds
+    var lastScrollViewBounds: CGRect?
+    
     let kCardCellIndentifier = "CardCell"
     public var collectionView : UICollectionView!
     var layout : UICollectionViewFlowLayout!
@@ -79,6 +82,15 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView]))
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView]))
 
+    }
+    
+    // functionality that happens when the view appears
+    open override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // make sure that we set this as the first time we are checking for visibility
+        lastScrollViewBounds = nil
+        notifyCardsVisibility()
     }
 	
     public func invalidateLayout() {
@@ -357,5 +369,25 @@ extension CardsViewController {
 // scroll view delegate extension. This allows subclasses of CardsViewController to implement these scroll view delegate methods
 extension CardsViewController {
     
-    open func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {}
+    // calls visibility delegates as needed with the appropriate frame
+    open func notifyCardsVisibility() {
+        if CardUtils.isSignificantScroll(lastScrollBounds: lastScrollViewBounds, currentScrollBounds: collectionView.bounds, threshold: 0.0) {
+            // for all visible cells go through and calaculate visibility and pass along to CardPartsViewControllers
+            collectionView.visibleCells.flatMap { ($0 as? CardCell) }.forEach { (cell) in
+                guard let indexPath = collectionView.indexPath(for: cell) else { return }
+                let cardController = getCardControllerForIndexPath(indexPath: indexPath)
+                
+                if let vc = cardController as? CardPartsViewController {
+                    vc.cardVisibility(percentVisible: CardUtils.cardVisibility(containerFrame: collectionView.bounds, cardFrame: cell.frame))
+                }
+            }
+        }
+        
+        lastScrollViewBounds = collectionView.bounds
+    }
+    
+    // calls for visibility of card when the scroll view scrolls
+    open func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        notifyCardsVisibility()
+    }
 }

--- a/Delegates/CardVisibilityDelegate.swift
+++ b/Delegates/CardVisibilityDelegate.swift
@@ -1,0 +1,20 @@
+//
+//  CardVisibilityDelegate.swift
+//  CardParts
+//
+//  Created by Tumer, Deniz on 5/23/18.
+//
+
+/*
+ * This protocol handles passing data about the visibility of a card
+ * from an instance of a CardsViewController to the card itself
+ */
+@objc public protocol CardVisibilityDelegate {
+    
+    /*
+     * Notifies a card of its visibility.
+     *
+     * @param percentVisible - percentage of the card that is visible in the list of cards
+     */
+    @objc optional func cardVisibility(percentVisible: CGFloat)
+}

--- a/Example/CardParts.xcodeproj/project.pbxproj
+++ b/Example/CardParts.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0440417302BC32AC38512DEC /* Pods_CardParts_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CB26A08A06535707936D4C9 /* Pods_CardParts_Example.framework */; };
+		55AB80CF20B61E1700B5994B /* CardUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AB80CE20B61E1700B5994B /* CardUtilsTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* MainViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -54,6 +55,7 @@
 		2BA2B86E3C2946F91C18390D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		30570F5B2E2268AA7B34EEC0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		38D4FF89FE9B4649B809A674 /* Pods-CardParts_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		55AB80CE20B61E1700B5994B /* CardUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardUtilsTests.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* CardParts_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardParts_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				61D4706B1FDA709B00F451F0 /* CardPartTitleViewTests.swift */,
 				61D470841FDB08EE00F451F0 /* CardPartTitleDescriptionViewTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				55AB80CE20B61E1700B5994B /* CardUtilsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 			files = (
 				61D470751FDA709B00F451F0 /* CardPartButtonViewTests.swift in Sources */,
 				61D470721FDA709B00F451F0 /* CardPartTitleViewTests.swift in Sources */,
+				55AB80CF20B61E1700B5994B /* CardUtilsTests.swift in Sources */,
 				61D470731FDA709B00F451F0 /* CardPartSeparatorViewTests.swift in Sources */,
 				61D470741FDA709B00F451F0 /* CardPartTextViewTests.swift in Sources */,
 				61D470711FDA709B00F451F0 /* CardPartImageViewTests.swift in Sources */,

--- a/Example/CardParts/CardPartImageViewCardController.swift
+++ b/Example/CardParts/CardPartImageViewCardController.swift
@@ -9,20 +9,28 @@
 import Foundation
 import CardParts
 
-class CardPartImageViewCardController: CardPartsViewController {
+class CardPartImageViewCardController: CardPartsViewController, CardVisibilityDelegate {
     
     let cardPartTextView = CardPartTextView(type: .normal)
+    let cardPartTextLogView = CardPartTextView(type: .normal)
     let cardPartImage = CardPartImageView(image: UIImage(named: "cardPartsLogo"))
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         cardPartTextView.text = "This is a CardPartImageView"
+        cardPartTextLogView.text = "PS - Check the Xcode logs while you scroll this card!"
         
         cardPartImage.addConstraint(NSLayoutConstraint(item: cardPartImage, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 300))
         cardPartImage.addConstraint(NSLayoutConstraint(item: cardPartImage, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 300))
         
-        setupCardParts([cardPartTextView, cardPartImage])
+        setupCardParts([cardPartTextView, cardPartTextLogView, cardPartImage])
+    }
+    
+    // allows us access to see the percent visibility of this card
+    // This is only called when the visibility of the card changes
+    func cardVisibility(percentVisible: CGFloat) {
+        print("This image view is \(percentVisible *  100)% visible!")
     }
 }
 

--- a/Example/Tests/CardUtilsTests.swift
+++ b/Example/Tests/CardUtilsTests.swift
@@ -1,0 +1,178 @@
+//
+//  CardUtilsTests.swift
+//  CardParts_Tests
+//
+//  Created by Tumer, Deniz on 5/23/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import CardParts
+
+class CardUtilsTests: XCTestCase {
+    
+    // tests if the card is visible
+    func testIsCardVisibleForRatio() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 1000)
+        let cardFrame = CGRect(x: 0, y: 0, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 1.0)
+    }
+    
+    // tests if the card is visible if only the top half is visible
+    func testIsCardVisibleForRatioHalfTop() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 1000)
+        let cardFrame = CGRect(x: 0, y: 950, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.5)
+    }
+    
+    // tests if the card is visible if only the bottom half is visible
+    func testIsCardVisibleForRatioHalfBottom() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 1000)
+        let cardFrame = CGRect(x: 0, y: -50, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.5)
+    }
+    
+    // tests if there isnt half of the card showing
+    func testIsCardVisibleForRatioNotVisible1() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 1000)
+        let cardFrame = CGRect(x: 0, y: -75, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.25)
+    }
+    
+    // tests if there isnt half of the card showing
+    func testIsCardVisibleForRatioNotVisible2() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 100)
+        let cardFrame = CGRect(x: 0, y: -51, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.49)
+    }
+    
+    // tests if there isnt half of the card showing
+    func testIsCardVisibleForRatioNotVisible3() {
+        let containerFrame = CGRect(x: 0, y: 0, width: 300, height: 1000)
+        let cardFrame = CGRect(x: 0, y: 960, width: 280, height: 100)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.4)
+    }
+    
+    // tests card in full view in different area of scroll view
+    func testIsCardVisibleTrue1() {
+        let containerFrame = CGRect(x: 0, y: 621.5, width: 375, height: 603.1)
+        let cardFrame = CGRect(x: 12.0, y: 691.5, width: 351.0, height: 386.5)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 1.0)
+    }
+    
+    // tests card cut off at top of screen in different area of scroll view
+    func testCardNotVisible() {
+        let containerFrame = CGRect(x: 0, y: 621.5, width: 375, height: 603.1)
+        let cardFrame = CGRect(x: 12.0, y: 400.5, width: 351.0, height: 386.5)
+        let calc = (cardFrame.height - (containerFrame.origin.y - cardFrame.origin.y)) / cardFrame.height
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), calc)
+    }
+    
+    // tests card cut off at bottom of screen in different area of scroll view
+    func testIsCardVisibleCutOffBottom() {
+        let containerFrame = CGRect(x: 0, y: 621.5, width: 375, height: 603.1)
+        let cardFrame = CGRect(x: 12.0, y: 1050, width: 351.0, height: 386.5)
+        let calc = (containerFrame.origin.y + containerFrame.height - cardFrame.origin.y) / cardFrame.height
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), calc)
+    }
+    
+    // tests card cut off at bottom of screen in different area of scroll view
+    func testIsCardVisibleCutOffBottom1() {
+        let containerFrame = CGRect(x: 0, y: 621.5, width: 375, height: 603.1)
+        let cardFrame = CGRect(x: 12.0, y: 1060, width: 351.0, height: 300.5)
+        let calc = (containerFrame.origin.y + containerFrame.height - cardFrame.origin.y) / cardFrame.height
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), calc)
+    }
+    
+    // tests if card is not in view below current scroll view bounds
+    func testIsCardNotVisibleBelowScrollViewBounds() {
+        let containerFrame = CGRect(x: 0, y: 33.0, width: 375, height: 603.0)
+        let cardFrame = CGRect(x: 12.0, y: 691.5, width: 351.0, height: 386.5)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.0)
+    }
+    
+    // test card not in view above current scroll view bounds
+    func testIsCardNotVisibleAboveScrollViewBounds() {
+        let containerFrame = CGRect(x: 0, y: 885, width: 375, height: 603.0)
+        let cardFrame = CGRect(x: 12.0, y: 691.5, width: 351.0, height: 386.5)
+        let calc = (cardFrame.height - (containerFrame.origin.y - cardFrame.origin.y)) / cardFrame.height
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), calc)
+    }
+    
+    // test card visible at edge above
+    func testIsCardVisibleAboveScrollViewAtEdge() {
+        let containerFrame = CGRect(x: 0, y: 750, width: 375, height: 600)
+        let cardFrame = CGRect(x: 12.0, y: 600, width: 351.0, height: 300)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 0.5)
+    }
+    
+    // test card visible at edge below
+    func testIsCardVisibleBelowScrollViewAtEdge() {
+        let containerFrame = CGRect(x: 0, y: 450, width: 375, height: 600)
+        let cardFrame = CGRect(x: 12.0, y: 600, width: 351.0, height: 300)
+        
+        XCTAssertEqual(CardUtils.cardVisibility(containerFrame: containerFrame, cardFrame: cardFrame), 1.0)
+    }
+}
+
+// tests for is significant scroll
+extension CardUtilsTests {
+    
+    // tests that we don't reach the threshold value in our scroll positively
+    func testNotSignificantScrollPositive() {
+        let lastScrollBounds = CGRect(x: 0, y: 0, width: 375, height: 1800)
+        let currentScrollBounds = CGRect(x: 0, y: 9, width: 375, height: 1800)
+        let threshold: CGFloat = 10.0
+        
+        XCTAssertFalse(CardUtils.isSignificantScroll(lastScrollBounds: lastScrollBounds, currentScrollBounds: currentScrollBounds, threshold: threshold))
+    }
+    
+    // tests that we don't reach the threshold value of our scroll negatively
+    func testNotSignificantScrollNegative() {
+        let lastScrollBounds = CGRect(x: 0, y: 0, width: 375, height: 1800)
+        let currentScrollBounds = CGRect(x: 0, y: -8, width: 375, height: 1800)
+        let threshold: CGFloat = 10.0
+        
+        XCTAssertFalse(CardUtils.isSignificantScroll(lastScrollBounds: lastScrollBounds, currentScrollBounds: currentScrollBounds, threshold: threshold))
+    }
+    
+    // tests that we do reach the threshold value of our scroll positively
+    func testSignificantScrollPositive() {
+        let lastScrollBounds = CGRect(x: 0, y: 0, width: 375, height: 1800)
+        let currentScrollBounds = CGRect(x: 0, y: 20, width: 375, height: 1800)
+        let threshold: CGFloat = 10.0
+        
+        XCTAssertTrue(CardUtils.isSignificantScroll(lastScrollBounds: lastScrollBounds, currentScrollBounds: currentScrollBounds, threshold: threshold))
+    }
+    
+    // tests that we do reach the threshold value of our scroll negatively
+    func testSignificantScrollNegative() {
+        let lastScrollBounds = CGRect(x: 0, y: 0, width: 375, height: 1800)
+        let currentScrollBounds = CGRect(x: 0, y: -20, width: 375, height: 1800)
+        let threshold: CGFloat = 10.0
+        
+        XCTAssertTrue(CardUtils.isSignificantScroll(lastScrollBounds: lastScrollBounds, currentScrollBounds: currentScrollBounds, threshold: threshold))
+    }
+    
+    // tests nil last scroll bounds
+    func testNilLastScroll() {
+        let lastScrollBounds: CGRect? = nil
+        let currentScrollBounds = CGRect(x: 0, y: -20, width: 375, height: 1800)
+        let threshold: CGFloat = 10.0
+        
+        XCTAssertTrue(CardUtils.isSignificantScroll(lastScrollBounds: lastScrollBounds, currentScrollBounds: currentScrollBounds, threshold: threshold))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -758,6 +758,20 @@ public class YourCardPartTheme: CardPartsTheme {
 ```
 And then in your `AppDelegete` call `YourCardPartTheme().apply()` it apply your theme.
 
+## Listeners
+Card Parts also support a listener that allows you to listen to visibility changes in the cards that you have created. In your `CardPartsViewController` you may override the following function to gain insight into the visibility of your card within the `CardsViewController` you have created.
+```swift
+public class YourCardPartsViewController: CardPartsViewController {
+    ...
+
+    // Notifies your card parts view controller of the percentage of the card that is visible.
+    // This function is called every time 'scrollViewDidScroll' is called in your CardsViewController.
+    override func cardVisibility(percentVisible: CGFloat) {
+        // logic you would like to perform when the scroll view has scrolled
+    }
+}
+```
+
 # Apps That Love CardParts
 - [Mint - Personal Finance & Money](https://itunes.apple.com/us/app/mint-personal-finance-money/id300238550?mt=8)
 - [Turbo: Scores-Income & Credit](https://itunes.apple.com/us/app/turbo-scores-income-credit/id1242998361?mt=8)

--- a/Utilities/CardUtils.swift
+++ b/Utilities/CardUtils.swift
@@ -1,0 +1,62 @@
+//
+//  CardUtils.swift
+//  CardParts
+//
+//  Created by Tumer, Deniz on 5/23/18.
+//
+
+import Foundation
+
+/*
+ * Defines utility methods for cards.
+ */
+class CardUtils {
+    
+    /*
+     * Given the card's frame and the frame of the container determine the percentage of the card that is visible in the container's bounds
+     *
+     * @param containerFrame - The frame bounds of the container
+     * @param cardFrame - The frame bounds of the card
+     *
+     * @return The percentage of the card that is visible within the specified container frame
+     */
+    class func cardVisibility(containerFrame: CGRect, cardFrame: CGRect) -> CGFloat {
+        var visibleHeight: CGFloat = 0.0
+        let cardFrameBottomY = cardFrame.origin.y + cardFrame.height
+        let containerFrameBottomY = containerFrame.origin.y + containerFrame.height
+        
+        // if the top of the card is cut off by the top of the container
+        if cardFrame.origin.y < containerFrame.origin.y && cardFrameBottomY > containerFrame.origin.y {
+            visibleHeight = cardFrame.height - (containerFrame.origin.y - cardFrame.origin.y)
+        }
+        // if the bottom of the card is cut off by the container
+        else if cardFrameBottomY > containerFrameBottomY && cardFrame.origin.y < containerFrameBottomY {
+            visibleHeight = containerFrame.origin.y + containerFrame.height - cardFrame.origin.y
+        }
+        // else the card is in full view
+        else if cardFrame.origin.y >= containerFrame.origin.y && cardFrameBottomY <= containerFrameBottomY {
+            visibleHeight = cardFrame.height
+        }
+            // not in the visible view
+        else {
+            return 0.0
+        }
+        
+        return visibleHeight / cardFrame.height
+    }
+    
+    /*
+     * Checks to see if the scroll of the scroll view was significant. Significance of the scroll depends on a threshold pixel value.
+     *
+     * @param lastScrollBounds - The rectangle of the boundary of the last scroll that occurred
+     * @param currentSctollBounds - The rectangle of the boundary of the current scroll that occurred
+     * @param threshold - The pixel threshold of the scroll. The scroll bounds of the last and current scroll must differ by at more than this value (>)
+     */
+    class func isSignificantScroll(lastScrollBounds: CGRect?, currentScrollBounds: CGRect, threshold: CGFloat) -> Bool {
+        guard let bounds = lastScrollBounds else {
+            return true
+        }
+
+        return abs(bounds.origin.y - currentScrollBounds.origin.y) > threshold
+    }
+}


### PR DESCRIPTION
Adds a listener in CardPartsViewController that allows for custom CardPartsViewControllers to be notified of the visibility of the card within a custom CardsViewController implementation.

Every time scrollViewDidScroll() is called in the CardsViewController the corresponding "cardVisibility(percentVisible: CGFloat)" function is called if the card in question is visible within the bounds of the scroll view. The card is then notified of the percentage of itself that is visible.