### PR TITLE
Bump podspec

### DIFF
--- a/CardParts.podspec
+++ b/CardParts.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CardParts'
-  s.version          = '2.3.2'
+  s.version          = '2.3.3'
   s.platform         = :ios
   s.summary          = 'iOS Card UI framework.'
 


### PR DESCRIPTION
This is for release 2.3.3 which will add delegate for card visibility.  See #15 for reference.