### PR TITLE
Tweak for issue #19 to fix the going off the right edge of the CardPartTitleView

### DIFF
--- a/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
@@ -108,7 +108,7 @@ public class CardPartTitleView : UIView, CardPartView {
 	
 	override public func updateConstraints() {
 		addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[label]|", options: [], metrics: nil, views: ["label" : label]))
-		addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[label]", options: [], metrics: nil, views: ["label" : label]))		
+		addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[label]|", options: [], metrics: nil, views: ["label" : label]))		
 		if let button = button {
 			addConstraints([NSLayoutConstraint (item: button,
 			                                    attribute: NSLayoutAttribute.width,


### PR DESCRIPTION
The CardPartTitleView was setting the horizontal constraint to pin left, but nothing on the right, so the UILabel just floated off of the containing CardPartVIew.

Figured this fix was good because then the developer can decide if they want to go further in fixing up their label (vs CardParts deciding for them).

iPhone SE:

![iphone se](https://user-images.githubusercontent.com/50843/40761819-262dc2da-6452-11e8-96b3-7f6b0b096a11.png)

iPhone X:

![iphone x](https://user-images.githubusercontent.com/50843/40761832-35dd57a4-6452-11e8-8b49-79dfb712158a.png)

iPhone 8 Plus:

![iphone 8 plus](https://user-images.githubusercontent.com/50843/40761841-3fd4ffc8-6452-11e8-95c9-9297f81dca85.png)

@croossin Have a look and let me know what you think. 
