### PR TITLE
Update CardPartTextView.swift

### DIFF
--- a/CardParts/src/Classes/Card Parts/CardPartTextView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTextView.swift
@@ -35,7 +35,6 @@ public class CardPartTextView : UIView, CardPartView, TTTAttributedLabelDelegate
 	
 	public var font: UIFont! {
 		didSet {
-			label.font = font
 			updateText()
 		}
 	}
@@ -153,7 +152,7 @@ public class CardPartTextView : UIView, CardPartView, TTTAttributedLabelDelegate
 			
             mutableAttrText.addAttributes([NSAttributedStringKey.paragraphStyle: paragraphStyle],
 			                              range: NSRange(location: 0, length: mutableAttrText.length))
-
+			label.font = font
 			label.textAlignment = textAlignment
 			label.setText(mutableAttrText)
 			

--- a/CardParts/src/Classes/Card Parts/CardPartTextView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTextView.swift
@@ -35,6 +35,7 @@ public class CardPartTextView : UIView, CardPartView, TTTAttributedLabelDelegate
 	
 	public var font: UIFont! {
 		didSet {
+			label.font = font
 			updateText()
 		}
 	}


### PR DESCRIPTION
forcing font attribute to label to prevent 'y' cutoff on larger fonts.

For some reason without reseting the base font to the TTAttributed label, using larger fonts cut off the baseline.