### PR TITLE
Adds custom states to CardParts

### DIFF
--- a/CardParts/src/Classes/CardPartsViewController.swift
+++ b/CardParts/src/Classes/CardPartsViewController.swift
@@ -10,11 +10,11 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-public enum CardState {
-	case none
-	case loading
-	case empty
-	case hasData
+public struct CardState {
+    public static let none = "none"
+    public static let loading = "loading"
+    public static let empty = "empty"
+    public static let hasData = "hasData"
 }
 
 class CardStateData {
@@ -27,7 +27,7 @@ open class CardPartsViewController : UIViewController, CardController {
     public var isEditable = false
 	var vertContraints: [NSLayoutConstraint]?
 	
-	public var state: CardState = .none {
+	public var state: String = CardState.none {
 		didSet {
 			updateState(oldState: oldValue, newState: state)
 		}
@@ -41,7 +41,7 @@ open class CardPartsViewController : UIViewController, CardController {
     // MARK: Clickable traits
     private var cardTapGesture: UITapGestureRecognizer?
     
-    private var cardClickedCallback: [CardState: (()->())] = [:] {
+    private var cardClickedCallback: [String: (()->())] = [:] {
         
         didSet {
             // We don't have a tap gesture setup, let's add
@@ -55,7 +55,7 @@ open class CardPartsViewController : UIViewController, CardController {
         }
     }
 	
-	private var cardParts:[CardState : CardStateData] = [:]
+	private var cardParts:[String : CardStateData] = [:]
 	
 	public let bag = DisposeBag()
     
@@ -69,7 +69,7 @@ open class CardPartsViewController : UIViewController, CardController {
         super.viewDidLoad()
     }
 
-	public func setupCardParts(_ cardParts:[CardPartView], forState: CardState = .none) {
+	public func setupCardParts(_ cardParts:[CardPartView], forState: String = CardState.none) {
 		
         let stateData = CardStateData()
         stateData.cardParts = cardParts
@@ -132,18 +132,18 @@ open class CardPartsViewController : UIViewController, CardController {
 		}
 	}
 	
-	private func updateState(oldState: CardState, newState: CardState) {
+	private func updateState(oldState: String, newState: String) {
 		if oldState == newState { return }
         removeCardPartsForState(oldState)
         addCardPartsForState(newState)
 		invalidateLayout()
 	}
     
-    public func cardTapped(forState state: CardState = .none, action: @escaping (()->())) {
+    public func cardTapped(forState state: String = CardState.none, action: @escaping (()->())) {
         self.cardClickedCallback[state] = action
     }
     
-    private func addCardPartsForState(_ state: CardState) {
+    private func addCardPartsForState(_ state: String) {
         if let stateData = cardParts[state] {
             stateData.cardParts.forEach {
                 if let cardViewController = $0.viewController {
@@ -158,7 +158,7 @@ open class CardPartsViewController : UIViewController, CardController {
         }
     }
 
-    private func removeCardPartsForState(_ state: CardState) {
+    private func removeCardPartsForState(_ state: String) {
         if let stateData = cardParts[state] {
             stateData.cardParts.forEach {
                 if let cardViewController = $0.viewController {
@@ -190,7 +190,7 @@ extension CardPartsViewController {
 
 extension Reactive where Base: CardPartsViewController {
 	
-	public var state: Binder<CardState>{
+	public var state: Binder<String>{
 		return Binder(self.base) { (cardPartsViewController, state) -> () in
 			cardPartsViewController.state = state
 		}

--- a/Example/CardParts.xcodeproj/project.pbxproj
+++ b/Example/CardParts.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		70F595DA20B5C9F200B6E688 /* CardPartStackViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595D920B5C9F200B6E688 /* CardPartStackViewCardController.swift */; };
 		70F595DC20B5CAF800B6E688 /* CardPartTableViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595DB20B5CAF800B6E688 /* CardPartTableViewCardController.swift */; };
 		70F595E020B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595DF20B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift */; };
+		83A790A5BC2AF59250F714F1 /* Pods_CardParts_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */; };
+		C199803C04DF369C93E5C83A /* Pods_CardParts_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +54,7 @@
 /* Begin PBXFileReference section */
 		2BA2B86E3C2946F91C18390D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		30570F5B2E2268AA7B34EEC0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example.release.xcconfig"; sourceTree = "<group>"; };
 		55AB80CE20B61E1700B5994B /* CardUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardUtilsTests.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* CardParts_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardParts_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -86,7 +89,12 @@
 		70F595D920B5C9F200B6E688 /* CardPartStackViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartStackViewCardController.swift; sourceTree = "<group>"; };
 		70F595DB20B5CAF800B6E688 /* CardPartTableViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartTableViewCardController.swift; sourceTree = "<group>"; };
 		70F595DF20B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartCollectionViewCardController.swift; sourceTree = "<group>"; };
+		807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CardParts_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CardParts_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED96724FD3D3088F4E52A4B3 /* CardParts.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = CardParts.podspec; path = ../CardParts.podspec; sourceTree = "<group>"; };
+		F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83A790A5BC2AF59250F714F1 /* Pods_CardParts_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,12 +110,24 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C199803C04DF369C93E5C83A /* Pods_CardParts_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		06828A6C9E307AE72B02934E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */,
+				30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */,
+				B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */,
+				AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
@@ -114,6 +135,8 @@
 				607FACD21AFB9204008FA782 /* Example for CardParts */,
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
+				06828A6C9E307AE72B02934E /* Pods */,
+				738918B116993C95F6D1D927 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -207,6 +230,15 @@
 			name = "Type of CardParts";
 			sourceTree = "<group>";
 		};
+		738918B116993C95F6D1D927 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */,
+				807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -214,9 +246,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "CardParts_Example" */;
 			buildPhases = (
+				367CD85B1951CCB6B08A5B6D /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
+				C6E983B07E8E9F8D4D7DC5FD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -231,9 +265,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "CardParts_Tests" */;
 			buildPhases = (
+				6ECFCD9C3ADE244E0D976A67 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
+				B3714D7B1296E210CE4AAB62 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -306,6 +342,101 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		367CD85B1951CCB6B08A5B6D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CardParts_Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6ECFCD9C3ADE244E0D976A67 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CardParts_Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B3714D7B1296E210CE4AAB62 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CardParts/CardParts.framework",
+				"${BUILT_PRODUCTS_DIR}/Differentiator/Differentiator.framework",
+				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxDataSources/RxDataSources.framework",
+				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardParts.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Differentiator.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxDataSources.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C6E983B07E8E9F8D4D7DC5FD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CardParts/CardParts.framework",
+				"${BUILT_PRODUCTS_DIR}/Differentiator/Differentiator.framework",
+				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxDataSources/RxDataSources.framework",
+				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardParts.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Differentiator.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxDataSources.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		607FACCC1AFB9204008FA782 /* Sources */ = {
@@ -480,6 +611,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FPR5C96X44;
@@ -497,6 +629,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FPR5C96X44;
@@ -514,6 +647,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */;
 			buildSettings = {
 				DEVELOPMENT_TEAM = FPR5C96X44;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -536,6 +670,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */;
 			buildSettings = {
 				DEVELOPMENT_TEAM = FPR5C96X44;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Example/CardParts.xcodeproj/project.pbxproj
+++ b/Example/CardParts.xcodeproj/project.pbxproj
@@ -37,8 +37,6 @@
 		70F595DA20B5C9F200B6E688 /* CardPartStackViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595D920B5C9F200B6E688 /* CardPartStackViewCardController.swift */; };
 		70F595DC20B5CAF800B6E688 /* CardPartTableViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595DB20B5CAF800B6E688 /* CardPartTableViewCardController.swift */; };
 		70F595E020B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F595DF20B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift */; };
-		83A790A5BC2AF59250F714F1 /* Pods_CardParts_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */; };
-		C199803C04DF369C93E5C83A /* Pods_CardParts_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,7 +52,6 @@
 /* Begin PBXFileReference section */
 		2BA2B86E3C2946F91C18390D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		30570F5B2E2268AA7B34EEC0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example.release.xcconfig"; sourceTree = "<group>"; };
 		55AB80CE20B61E1700B5994B /* CardUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardUtilsTests.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* CardParts_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardParts_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -89,12 +86,7 @@
 		70F595D920B5C9F200B6E688 /* CardPartStackViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartStackViewCardController.swift; sourceTree = "<group>"; };
 		70F595DB20B5CAF800B6E688 /* CardPartTableViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartTableViewCardController.swift; sourceTree = "<group>"; };
 		70F595DF20B5CDCE00B6E688 /* CardPartCollectionViewCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartCollectionViewCardController.swift; sourceTree = "<group>"; };
-		807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CardParts_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CardParts_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED96724FD3D3088F4E52A4B3 /* CardParts.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = CardParts.podspec; path = ../CardParts.podspec; sourceTree = "<group>"; };
-		F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,7 +94,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				83A790A5BC2AF59250F714F1 /* Pods_CardParts_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,24 +101,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C199803C04DF369C93E5C83A /* Pods_CardParts_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		06828A6C9E307AE72B02934E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */,
-				30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */,
-				B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */,
-				AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
@@ -135,8 +114,6 @@
 				607FACD21AFB9204008FA782 /* Example for CardParts */,
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
-				06828A6C9E307AE72B02934E /* Pods */,
-				738918B116993C95F6D1D927 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -230,15 +207,6 @@
 			name = "Type of CardParts";
 			sourceTree = "<group>";
 		};
-		738918B116993C95F6D1D927 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				E9067791475DE459247FA939 /* Pods_CardParts_Example.framework */,
-				807725C6DC7EB380FE180208 /* Pods_CardParts_Tests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -246,11 +214,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "CardParts_Example" */;
 			buildPhases = (
-				367CD85B1951CCB6B08A5B6D /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				C6E983B07E8E9F8D4D7DC5FD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -265,11 +231,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "CardParts_Tests" */;
 			buildPhases = (
-				6ECFCD9C3ADE244E0D976A67 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
-				B3714D7B1296E210CE4AAB62 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -342,101 +306,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		367CD85B1951CCB6B08A5B6D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-CardParts_Example-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6ECFCD9C3ADE244E0D976A67 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-CardParts_Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B3714D7B1296E210CE4AAB62 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CardParts/CardParts.framework",
-				"${BUILT_PRODUCTS_DIR}/Differentiator/Differentiator.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
-				"${BUILT_PRODUCTS_DIR}/RxDataSources/RxDataSources.framework",
-				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardParts.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Differentiator.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxDataSources.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C6E983B07E8E9F8D4D7DC5FD /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CardParts/CardParts.framework",
-				"${BUILT_PRODUCTS_DIR}/Differentiator/Differentiator.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
-				"${BUILT_PRODUCTS_DIR}/RxDataSources/RxDataSources.framework",
-				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/TTTAttributedLabel/TTTAttributedLabel.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardParts.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Differentiator.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxDataSources.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TTTAttributedLabel.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CardParts_Example/Pods-CardParts_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		607FACCC1AFB9204008FA782 /* Sources */ = {
@@ -611,7 +480,6 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1B721C03D8163C4C79A33A1 /* Pods-CardParts_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FPR5C96X44;
@@ -629,7 +497,6 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 30A11799FD9731412B31F7EF /* Pods-CardParts_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FPR5C96X44;
@@ -647,7 +514,6 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B30DFF28C7415B1DAEF4E1C2 /* Pods-CardParts_Tests.debug.xcconfig */;
 			buildSettings = {
 				DEVELOPMENT_TEAM = FPR5C96X44;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -670,7 +536,6 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AA2B46AB92C7772E37C7FEA5 /* Pods-CardParts_Tests.release.xcconfig */;
 			buildSettings = {
 				DEVELOPMENT_TEAM = FPR5C96X44;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Example/CardParts/CardPartOrientedViewCardController.swift
+++ b/Example/CardParts/CardPartOrientedViewCardController.swift
@@ -28,10 +28,10 @@ class CardPartOrientedViewCardController: CardPartsViewController {
         super.viewDidLoad()
         
         // setup oriented elements
-        setupCardParts([getTopOrientedContainer()], forState: .empty)
-        setupCardParts([getBottomOrientedContainer()], forState: .hasData)
+        setupCardParts([getTopOrientedContainer()], forState: CardState.empty)
+        setupCardParts([getBottomOrientedContainer()], forState: CardState.hasData)
         
-        state = .hasData
+        state = CardState.hasData
     }
     
     // get top container with elements
@@ -100,11 +100,11 @@ class CardPartOrientedViewCardController: CardPartsViewController {
     }
     
     @objc func toggleOrientation() {
-        if state == .empty {
-            state = .hasData
+        if state == CardState.empty {
+            state = CardState.hasData
         }
         else {
-            state = .empty
+            state = CardState.empty
         }
     }
 }

--- a/Example/CardParts/StateCardController.swift
+++ b/Example/CardParts/StateCardController.swift
@@ -11,6 +11,10 @@ import CardParts
 import RxSwift
 import RxCocoa
 
+extension CardState {
+    static let customState = "customState"
+}
+
 class StateCardController : CardPartsViewController {
 	
 	init() {
@@ -29,25 +33,32 @@ class StateCardController : CardPartsViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-        self.state = .empty
+        self.state = CardState.empty
 
         let textPart = CardPartTextView(type: .normal)
-		textPart.text = "Watch me change states!"
+		textPart.text = "This is the default empty state!"
 		
 		setupCardParts([textPart])
 
         let spacerPart = CardPartSpacerView(height: 200)
         
-        setupCardParts([textPart], forState: .empty)
-        setupCardParts([spacerPart], forState: .hasData)
+        let customTextPart = CardPartTextView(type: .normal)
+        customTextPart.text = "This is a custom state called 'customState'!"
         
+        setupCardParts([textPart], forState: CardState.empty)
+        setupCardParts([spacerPart], forState: CardState.hasData)
+        setupCardParts([customTextPart], forState: CardState.customState)
 	}
 	
 	@objc func toggleHidden() {
-        if state == .empty {
-            state = .hasData
-        } else {
-            state = .empty
+        if state == CardState.empty {
+            state = CardState.hasData
+        }
+        else if state == CardState.hasData {
+            state = CardState.customState
+        }
+        else {
+            state = CardState.empty
         }
 	}
 }

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ public enum CardPartTextFieldFormat {
 ```
 
 ## Card States
-CardPartsViewController can optionally support the notion of card states, where a card can be in 3 different states: loading, empty, and hasData. For each state you can specify a unique set of card parts to display. Then when the CardPartsViewController state property is changed, the framework will automatically switch the card parts to display the card parts for that state. Typically you would bind the state property to a state property in your view model so that when the view model changes state the card parts are changed. A simple example:
+CardPartsViewController can optionally support the notion of card states. There are 4 default states that a card can be in: none, empty, loading, and hasData. For each state you can specify a unique set of card parts to display. Then when the CardPartsViewController state property is changed, the framework will automatically switch the card parts to display the card parts for that state. Typically you would bind the state property to a state property in your view model so that when the view model changes state the card parts are changed. A simple example:
 
 ```swift
 class TestCardController : CardPartsViewController  {
@@ -719,9 +719,39 @@ class TestCardController : CardPartsViewController  {
 
         viewModel.state.asObservable().bind(to: self.rx.state).disposed(by: bag)
 
-        setupCardParts([titlePart, textPart], forState: .hasData)
-        setupCardParts([titlePart, loadingText], forState: .loading)
-        setupCardParts([titlePart, emptyText], forState: .empty)
+        setupCardParts([titlePart, textPart], forState: CardState.hasData)
+        setupCardParts([titlePart, loadingText], forState: CardState.loading)
+        setupCardParts([titlePart, emptyText], forState: CardState.empty)
+    }
+}
+```
+
+Since states are defined as strings you can easily create your own states and bind whatever elements you need to them! All you need to do is create an extension of the CardState structure and add your state names. Here is an example of how to create your own custom states:
+
+```swift
+extension CardState {
+    static let customState = "customState"
+}
+
+class CustomStateCardController : CardPartsViewController {
+
+    var viewModel = TestViewModel()
+    var titlePart = CardPartTitleView(type: .titleOnly)
+    var textPart = CardPartTextView(type: .normal)
+    var customText = CardPartTextView(type: .normal)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        viewModel.title.asObservable().bind(to: titlePart.reactive.title).disposed(by: bag)
+        viewModel.text.asObservable().bind(to: textPart.reactive.text).disposed(by: bag)
+
+        customText.text = "Some custom text for this state..."
+
+        viewModel.state.asObservable().bind(to: self.rx.state).disposed(by: bag)
+
+        setupCardParts([titlePart, textPart], forState: CardState.hasData)
+        setupCardParts([titlePart, cusomText], forState: CardState.customState)
     }
 }
 ```


### PR DESCRIPTION
Changes the definition of CardState to be a struct instead of an enum and its default states are now defined as strings. Defining the states as Strings allows for more customization by giving developers the ability to create an extension of the CardState structure and adding any custom states they would like to define.

See #36 for more details