### PR TITLE
Adding a flag to not listen to keyboard events. 

### DIFF
--- a/CardParts.podspec
+++ b/CardParts.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CardParts'
-  s.version          = '2.4.0'
+  s.version          = '2.4.1'
   s.platform         = :ios
   s.summary          = 'iOS Card UI framework.'
 

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -321,7 +321,7 @@ extension CardsViewController {
         notificationCenter.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
-    @objc private func keyboardWillShow(notification: Notification) {
+    @objc open func keyboardWillShow(notification: Notification) {
         guard var keyboardRect = (notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
               let keyboardCurve = (notification.userInfo?[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
               let keyboardDuration = (notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue,
@@ -366,7 +366,7 @@ extension CardsViewController {
         
     }
  
-    @objc private func keyboardWillHide(notification: Notification) {
+    @objc open func keyboardWillHide(notification: Notification) {
         guard let keyboardCurve = (notification.userInfo?[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
               let keyboardDuration = (notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
         else { return }

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -281,35 +281,47 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
     open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         UIResponder.first?.resignFirstResponder()
     }
+    
+    public var shouldListenToKeyboardNotifications: Bool = true {
+        didSet {
+            if shouldListenToKeyboardNotifications {
+                listenToKeyboardShowHideNotifications()
+            } else {
+                stopListeningToKeyboardShowHideNotifications()
+            }
+        }
+    }
 }
 
 extension CardsViewController {
     
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        listenToKeyboardShowHideNotifications()
+        if shouldListenToKeyboardNotifications {
+            listenToKeyboardShowHideNotifications()
+        }
     }
     
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
-        stopListeningToKeyboardShowHideNotifications()
+        if shouldListenToKeyboardNotifications {
+            stopListeningToKeyboardShowHideNotifications()
+        }
     }
     
-    public func listenToKeyboardShowHideNotifications() {
+    private func listenToKeyboardShowHideNotifications() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(keyboardWillShow), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         notificationCenter.addObserver(self, selector: #selector(keyboardWillHide), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
-    public func stopListeningToKeyboardShowHideNotifications() {
+    private func stopListeningToKeyboardShowHideNotifications() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         notificationCenter.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
-    @objc open func keyboardWillShow(notification: Notification) {
+    @objc private func keyboardWillShow(notification: Notification) {
         guard var keyboardRect = (notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
               let keyboardCurve = (notification.userInfo?[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
               let keyboardDuration = (notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue,
@@ -354,7 +366,7 @@ extension CardsViewController {
         
     }
  
-    @objc open func keyboardWillHide(notification: Notification) {
+    @objc private func keyboardWillHide(notification: Notification) {
         guard let keyboardCurve = (notification.userInfo?[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
               let keyboardDuration = (notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
         else { return }


### PR DESCRIPTION
By default it keeps listening to keyboard events and for some views it might not be required. Because  in certain situations if 3d touch on a notification which brings the keyboard, the view insets changes.