### PR TITLE
Making the bottom constraint to be greater or equal to superview.

### DIFF
--- a/CardParts/src/Classes/CardPartsViewController.swift
+++ b/CardParts/src/Classes/CardPartsViewController.swift
@@ -105,7 +105,7 @@ open class CardPartsViewController : UIViewController, CardController {
             padding = cardPart.margins.bottom
         }
         
-        stateData.constraints.append(NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: prevCardPart, attribute: .bottom, multiplier: 1.0, constant: padding))
+        stateData.constraints.append(NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .greaterThanOrEqual, toItem: prevCardPart, attribute: .bottom, multiplier: 1.0, constant: padding))
         
         if forState == self.state {
             view.addConstraints(stateData.constraints)


### PR DESCRIPTION
If somehow you want to make your card controller height as fixed, then equal would have messed up your constraints to fill the superviews.
With greaterOrEqual, the layout would be laid out properly regardless.