### PR TITLE
Fixes edge case where card is larger than container bounds

### DIFF
--- a/CardParts/src/Utilities/CardUtils.swift
+++ b/CardParts/src/Utilities/CardUtils.swift
@@ -26,8 +26,12 @@ class CardUtils {
         let cardFrameBottomY = cardFrame.origin.y + cardFrame.height
         let containerFrameBottomY = containerFrame.origin.y + containerFrame.height
         
+        // if the card is cut off at the top and bottom (card is too big and takes up more than the bounds)
+        if cardFrame.origin.y < containerFrame.origin.y && cardFrameBottomY > containerFrameBottomY {
+            visibleHeight = containerFrame.height  // we set visible height to the height of the container (it'll always be 100% visible)
+        }
         // if the top of the card is cut off by the top of the container
-        if cardFrame.origin.y < containerFrame.origin.y && cardFrameBottomY > containerFrame.origin.y {
+        else if cardFrame.origin.y < containerFrame.origin.y && cardFrameBottomY > containerFrame.origin.y {
             visibleHeight = cardFrame.height - (containerFrame.origin.y - cardFrame.origin.y)
         }
         // if the bottom of the card is cut off by the container

--- a/Example/Tests/CardUtilsTests.swift
+++ b/Example/Tests/CardUtilsTests.swift
@@ -162,6 +162,16 @@ class CardUtilsTests: XCTestCase {
         XCTAssertEqual(visibilityRatios.cardVisibilityRatio, 1.0)
         XCTAssertEqual(visibilityRatios.containerCoverageRatio, 0.5)
     }
+    
+    // test card cut off at top and bottom (card too big for container)
+    func testIsCardVisibleTooLarge() {
+        let containerBounds = CGRect(x: 0, y: 0, width: 400, height: 700)
+        let cardFrame = CGRect(x: 0, y: -20, width: 400, height: 1400)
+        let visibilityRatios = CardUtils.calculateVisibilityRatios(containerFrame: containerBounds, cardFrame: cardFrame)
+        
+        XCTAssertEqual(visibilityRatios.cardVisibilityRatio, 0.5)
+        XCTAssertEqual(visibilityRatios.containerCoverageRatio, 1.0)
+    }
 }
 
 // tests for is significant scroll


### PR DESCRIPTION
There was a huge edge case where if the card is larger than the bounds of the container the visibility delegate was not calculating the correct container coverage ratio