### PR TITLE
Fixing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ You can set the minimumPressDuration for your press to register as gesture began
 Example:
 
 ```swift
-extension MYOwnCardPartController: CardPartsLongGestureRecognizerDelegate {
+extension MYOwnCardPartController: CardPartsLongPressGestureRecognizerDelegate {
 	func didLongPress(_ gesture: UILongPressGestureRecognizer) {
 		guard let v = gesture.view else { return }
 


### PR DESCRIPTION
Simply fixing the typo of the name of the long press protocol
~CardPartsLongGestureRecognizerDelegate~ -> CardPartsLongPressGestureRecognizerDelegate

in example:
```swift
extension MYOwnCardPartController: CardPartsLongPressGestureRecognizerDelegate {
	func didLongPress(_ gesture: UILongPressGestureRecognizer) {
		guard let v = gesture.view else { return }

		switch gesture.state {
		case .began:
			// Zoom in
		case .ended, .cancelled:
			// Zoom out
		default: break
		}
	}
	// Gesture starts registering after pressing for more than 0.5 seconds.
	var minimumPressDuration: CFTimeInterval { return 0.5 }
}
```
