### PR TITLE
Added ability to provide shadow offset through ShadowCardTrait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+.DS_Store

--- a/CardParts/src/Classes/Card Parts/CardPartTableView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTableView.swift
@@ -33,7 +33,7 @@ private class SelfSizingTableView: UITableView {
 	}
 }
 
-@objc public protocol CardPartTableViewDelegte {
+@objc public protocol CardPartTableViewDelegate {
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath)
 	@objc optional func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat
 }
@@ -48,7 +48,7 @@ public class CardPartTableView : UIView, CardPartView, UITableViewDelegate {
 	
 	public var rowHeight: CGFloat = 60
 	
-	public var delegate: CardPartTableViewDelegte?
+	public var delegate: CardPartTableViewDelegate?
 	
 	public init() {
 		

--- a/CardParts/src/Classes/CardCell.swift
+++ b/CardParts/src/Classes/CardCell.swift
@@ -154,9 +154,9 @@ open class CardCell : UICollectionViewCell {
         }
     }
     
-    func addShadowToCard(shadowRadius: CGFloat = 8.0, shadowOpacity: Float = 0.7, shadowColor: CGColor = UIColor.Gray2.cgColor) {
+    func addShadowToCard(shadowRadius: CGFloat = 8.0, shadowOpacity: Float = 0.7, shadowColor: CGColor = UIColor.Gray2.cgColor, shadowOffset: CGSize = CGSize(width: 0, height: 5)) {
         contentView.layer.shadowColor = shadowColor
-        contentView.layer.shadowOffset = CGSize(width: 0, height: 5)
+        contentView.layer.shadowOffset = shadowOffset
         contentView.layer.shadowRadius = shadowRadius
         contentView.layer.shadowOpacity = shadowOpacity
     }

--- a/CardParts/src/Classes/CardController.swift
+++ b/CardParts/src/Classes/CardController.swift
@@ -65,6 +65,7 @@ public protocol ShadowCardTrait {
     func shadowColor() -> CGColor
     func shadowRadius() -> CGFloat
     func shadowOpacity() -> Float
+    func shadowOffset() -> CGSize
 }
 
 extension ShadowCardTrait {
@@ -78,6 +79,10 @@ extension ShadowCardTrait {
     
     func shadowOpacity() -> Float {
         return 0.7
+    }
+
+    func shadowOffset() -> CGSize {
+        return CGSize(width: 0, height: 5)
     }
 }
 

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -184,7 +184,7 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
 			cell.requiresTransparentCard(transparentCard: transparentCard)
 			
             if let shadowCardTrait = cardController as? ShadowCardTrait {
-                cell.addShadowToCard(shadowRadius: shadowCardTrait.shadowRadius(), shadowOpacity: shadowCardTrait.shadowOpacity(), shadowColor: shadowCardTrait.shadowColor())
+                cell.addShadowToCard(shadowRadius: shadowCardTrait.shadowRadius(), shadowOpacity: shadowCardTrait.shadowOpacity(), shadowColor: shadowCardTrait.shadowColor(), shadowOffset: shadowCardTrait.shadowOffset())
             }
             
             if let roundedCardTrait = cardController as? RoundedCardTrait {

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ It is also possible to register your own custom cells by calling the register me
 You also have access to two delegate methods being called by the tableView as follows:
 
 ```swift
-@objc public protocol CardPartTableViewDelegte {
+@objc public protocol CardPartTableViewDelegate {
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath)
 	@objc optional func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat
 }


### PR DESCRIPTION
I wanted to be able to provide a shadow offset to my cards that conformed to ShadowCardTrait to match the shadows in the rest of my app. This is a very small fix which adds this functionality. Looking at the source code, this was the only property hard coded so it makes sense to allow the developer to provide it.