### PR TITLE
Remove deprecated Variable and move to BehaviorRelay

### DIFF
--- a/CardParts/src/Classes/CardController.swift
+++ b/CardParts/src/Classes/CardController.swift
@@ -58,7 +58,7 @@ extension EditableCardTrait {
 
 public protocol HiddenCardTrait {
 	
-	var isHidden: Variable<Bool> { get }
+	var isHidden: BehaviorRelay<Bool> { get }
 }
 
 public protocol ShadowCardTrait {

--- a/CardParts/src/Classes/CardPartsViewController.swift
+++ b/CardParts/src/Classes/CardPartsViewController.swift
@@ -126,7 +126,7 @@ open class CardPartsViewController : UIViewController, CardController {
 		}
 	}
 	
-	public func invalidateLayout<T>(onChanges variables: [Variable<T>]) {
+	public func invalidateLayout<T>(onChanges variables: [BehaviorRelay<T>]) {
 		for variable in variables {
 			variable.asObservable().subscribe(onNext: { [weak self] _ in
 				self?.invalidateLayout()

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -38,7 +38,7 @@ struct CardInfo: Equatable {
 
 open class CardsViewController : UIViewController, UICollectionViewDataSource, UICollectionViewDelegate, UIScrollViewDelegate {
 	
-    let cardCellWidth = Variable(CGFloat(0))
+    let cardCellWidth = BehaviorRelay(value: CGFloat(0))
     let editButtonOffset : CGFloat = 24
     let editButtonHeight : CGFloat = 50
     let editButtonWidth : CGFloat = 50
@@ -82,11 +82,11 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
 
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
-	cardCellWidth.value = view.bounds.width - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right)
+        cardCellWidth.accept(view.bounds.width - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right))
     }
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        cardCellWidth.value = size.width - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right)
+        cardCellWidth.accept(size.width - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right))
         invalidateLayout()
     }
     

--- a/Example/CardParts/CardPartCollectionViewCardController.swift
+++ b/Example/CardParts/CardPartCollectionViewCardController.swift
@@ -79,8 +79,8 @@ class CardPartCollectionViewCardController: CardPartsViewController {
 
 class CardPartCollectionViewModel {
     
-    typealias ReactiveSection = Variable<[SectionOfCustomStruct]>
-    var data = ReactiveSection([])
+    typealias ReactiveSection = BehaviorRelay<[SectionOfCustomStruct]>
+    var data = ReactiveSection(value: [])
     
     let emojis: [String] = ["😎", "🤪", "🤩", "👻", "🤟🏽", "💋", "💃🏽"]
     
@@ -93,7 +93,7 @@ class CardPartCollectionViewModel {
             temp.append(MyStruct(title: "Title #\(i)", description: "\(emojis[Int(arc4random_uniform(UInt32(emojis.count)))])"))
         }
         
-        data.value = [SectionOfCustomStruct(header: "", items: temp)]
+        data.accept([SectionOfCustomStruct(header: "", items: temp)])
     }
 }
 

--- a/Example/CardParts/CardPartTableViewCardController.swift
+++ b/Example/CardParts/CardPartTableViewCardController.swift
@@ -37,7 +37,7 @@ class CardPartTableViewCardController: CardPartsViewController {
 
 class CardPartTableViewModel {
 
-    let listData: Variable<[String]> = Variable([])
+    let listData: BehaviorRelay<[String]> = BehaviorRelay(value: [])
     
     init() {
         
@@ -48,6 +48,6 @@ class CardPartTableViewModel {
             tempData.append("This is cell #\(i)")
         }
         
-        listData.value = tempData
+        listData.accept(tempData)
     }
 }

--- a/Example/CardParts/ReactiveCardController.swift
+++ b/Example/CardParts/ReactiveCardController.swift
@@ -30,7 +30,7 @@ class ReactiveCardViewModel {
 		case 1:
 			text.accept("this is some long text that should wrap the line. Do this work?")
 		case 2:
-			text.accept("this is some very very very very very very very very very very very very very very very long text that should wrap the line. Do this work?")
+			text.accept("this is some very very very very very very very very very very very very very very very long text that should wrap the line. Does this work?")
 		default:
 			return
 		}

--- a/Example/CardParts/ReactiveCardController.swift
+++ b/Example/CardParts/ReactiveCardController.swift
@@ -13,7 +13,7 @@ import RxCocoa
 
 class ReactiveCardViewModel {
 	
-	var text = Variable("")
+    var text = BehaviorRelay(value: "")
 	
 	init() {
 		startRandomText()
@@ -26,11 +26,11 @@ class ReactiveCardViewModel {
 	@objc func randomText() {
 		switch arc4random() % 3 {
 		case 0:
-			text.value = "short text"
+            text.accept("short text")
 		case 1:
-			text.value = "this is some long text that should wrap the line. Do this work?"
+			text.accept("this is some long text that should wrap the line. Do this work?")
 		case 2:
-			text.value = "this is some very very very very very very very very very very very very very very very long text that should wrap the line. Do this work?"
+			text.accept("this is some very very very very very very very very very very very very very very very long text that should wrap the line. Do this work?")
 		default:
 			return
 		}
@@ -40,7 +40,7 @@ class ReactiveCardViewModel {
 
 class ReactiveCardController : CardPartsViewController {
 	
-	var isHidden = Variable(false)
+	var isHidden = BehaviorRelay(value: false)
 	
 	var viewModel = ReactiveCardViewModel()
 	

--- a/Example/Tests/CardPartButtonViewTests.swift
+++ b/Example/Tests/CardPartButtonViewTests.swift
@@ -31,11 +31,11 @@ class CardPartButtonViewTests: XCTestCase {
 		let buttonPart = CardPartButtonView()
 		XCTAssertEqual(buttonPart.contentHorizontalAlignment, UIControl.ContentHorizontalAlignment.left)
 		
-		let horizAlignProperty = Variable<UIControl.ContentHorizontalAlignment>(.right)
+        let horizAlignProperty = BehaviorRelay<UIControl.ContentHorizontalAlignment>(value: .right)
 		horizAlignProperty.asObservable().bind(to: buttonPart.rx.contentHorizontalAlignment).disposed(by: bag)
 		XCTAssertEqual(buttonPart.contentHorizontalAlignment, UIControl.ContentHorizontalAlignment.right)
 		
-		horizAlignProperty.value = .center
+		horizAlignProperty.accept(.center)
 		XCTAssertEqual(buttonPart.contentHorizontalAlignment, UIControl.ContentHorizontalAlignment.center)
 	}
 	

--- a/Example/Tests/CardPartImageViewTests.swift
+++ b/Example/Tests/CardPartImageViewTests.swift
@@ -30,11 +30,11 @@ class CardPartImageViewTests: XCTestCase {
 		
 		let imagePart = CardPartImageView()
 		
-		let imageNameProperty = Variable("imageName")
+        let imageNameProperty = BehaviorRelay(value: "imageName")
 		imageNameProperty.asObservable().bind(to: imagePart.rx.imageName).disposed(by: bag)
 		XCTAssertEqual(imagePart.imageName, "imageName")
 		
-		imageNameProperty.value = "new value"
+		imageNameProperty.accept("new value")
 		XCTAssertEqual(imagePart.imageName, "new value")
 	}
 
@@ -44,11 +44,11 @@ class CardPartImageViewTests: XCTestCase {
 		
 		let imagePart = CardPartImageView()
 		
-		let contentModeProperty = Variable<UIView.ContentMode>(.scaleToFill)
+        let contentModeProperty = BehaviorRelay<UIView.ContentMode>(value: .scaleToFill)
 		contentModeProperty.asObservable().bind(to: imagePart.rx.contentMode).disposed(by: bag)
 		XCTAssertEqual(imagePart.contentMode, UIView.ContentMode.scaleToFill)
 		
-		contentModeProperty.value = .scaleAspectFit
+		contentModeProperty.accept(.scaleAspectFit)
 		XCTAssertEqual(imagePart.contentMode, UIView.ContentMode.scaleAspectFit)
 	}
 

--- a/Example/Tests/CardPartTextViewTests.swift
+++ b/Example/Tests/CardPartTextViewTests.swift
@@ -51,11 +51,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.text = "hello"
 		XCTAssertEqual("hello", textPart.label.text)
 		
-		let textProperty = Variable("testing")
+        let textProperty = BehaviorRelay(value: "testing")
         textProperty.asObservable().bind(to: textPart.rx.text).disposed(by: bag)
 		XCTAssertEqual("testing", textPart.label.text)
 
-		textProperty.value = "newValue"
+		textProperty.accept("newValue")
 		XCTAssertEqual("newValue", textPart.label.text)
     }
 
@@ -73,7 +73,7 @@ class CardPartTextViewTests: XCTestCase {
 		XCTAssertEqual(attrText.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as! UIColor,
 					   textPart.label.attributedText?.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as! UIColor)
 		
-		let textProperty = Variable(NSAttributedString(string: "testing", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font) : UIFont.boldSystemFont(ofSize: 50), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor) : UIColor.blue])))
+        let textProperty = BehaviorRelay(value: NSAttributedString(string: "testing", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font) : UIFont.boldSystemFont(ofSize: 50), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor) : UIColor.blue])))
         textProperty.asObservable().bind(to: textPart.rx.attributedText).disposed(by: bag)
 		XCTAssertEqual(textProperty.value.string, textPart.label.attributedText?.string)
 		XCTAssertEqual(textProperty.value.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as! UIFont,
@@ -81,7 +81,7 @@ class CardPartTextViewTests: XCTestCase {
 		XCTAssertEqual(textProperty.value.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as! UIColor,
 					   textPart.label.attributedText?.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as! UIColor)
 
-		textProperty.value = NSAttributedString(string: "newValue", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font) : UIFont.boldSystemFont(ofSize: 50), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor) : UIColor.green]))
+		textProperty.accept(NSAttributedString(string: "newValue", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font) : UIFont.boldSystemFont(ofSize: 50), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor) : UIColor.green])))
 		XCTAssertEqual(textProperty.value.string, textPart.label.attributedText?.string)
 		XCTAssertEqual(textProperty.value.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as! UIFont,
 					   textPart.label.attributedText?.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as! UIFont)
@@ -99,11 +99,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.font =  UIFont.boldSystemFont(ofSize: 20)
 		XCTAssertEqual(textPart.font, textPart.label.attributedText?.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as? UIFont)
 
-		let fontProperty = Variable(UIFont.boldSystemFont(ofSize: 50))
+        let fontProperty = BehaviorRelay(value: UIFont.boldSystemFont(ofSize: 50))
 		fontProperty.asObservable().bind(to: textPart.rx.font).disposed(by: bag)
 		XCTAssertEqual(fontProperty.value, textPart.label.attributedText?.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as? UIFont)
 
-		fontProperty.value = UIFont.boldSystemFont(ofSize: 10)
+		fontProperty.accept(UIFont.boldSystemFont(ofSize: 10))
 		XCTAssertEqual(fontProperty.value, textPart.label.attributedText?.attribute(NSAttributedString.Key.font, at:0, effectiveRange:nil) as? UIFont)
     }
 
@@ -117,11 +117,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.textColor =  UIColor.red
 		XCTAssertEqual(textPart.textColor, textPart.label.attributedText?.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as? UIColor)
 
-		let colorProperty = Variable(UIColor.green)
+        let colorProperty = BehaviorRelay(value: UIColor.green)
 		colorProperty.asObservable().bind(to: textPart.rx.textColor).disposed(by: bag)
 		XCTAssertEqual(colorProperty.value, textPart.label.attributedText?.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as? UIColor)
 
-		colorProperty.value = UIColor.blue
+		colorProperty.accept(UIColor.blue)
 		XCTAssertEqual(colorProperty.value, textPart.label.attributedText?.attribute(NSAttributedString.Key.foregroundColor, at:0, effectiveRange:nil) as? UIColor)
     }
 
@@ -135,11 +135,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.textAlignment = .right
 		XCTAssertEqual(textPart.textAlignment, textPart.label.textAlignment)
 
-		let alignProperty = Variable<NSTextAlignment>(.center)
+        let alignProperty = BehaviorRelay<NSTextAlignment>(value: .center)
 		alignProperty.asObservable().bind(to: textPart.rx.textAlignment).disposed(by: bag)
 		XCTAssertEqual(alignProperty.value, textPart.label.textAlignment)
 
-		alignProperty.value = .left
+		alignProperty.accept(.left)
 		XCTAssertEqual(alignProperty.value, textPart.label.textAlignment)
     }
 
@@ -153,11 +153,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.lineSpacing = 5.0
 		XCTAssertEqual(textPart.lineSpacing, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineSpacing)
 
-		let lineSpacingProperty = Variable<CGFloat>(2.5)
+        let lineSpacingProperty = BehaviorRelay<CGFloat>(value: 2.5)
 		lineSpacingProperty.asObservable().bind(to: textPart.rx.lineSpacing).disposed(by: bag)
 		XCTAssertEqual(textPart.lineSpacing, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineSpacing)
 
-		lineSpacingProperty.value = 1.0
+		lineSpacingProperty.accept(1.0)
 		XCTAssertEqual(textPart.lineSpacing, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineSpacing)
     }
 
@@ -171,11 +171,11 @@ class CardPartTextViewTests: XCTestCase {
 		textPart.lineHeightMultiple = 5.0
 		XCTAssertEqual(textPart.lineHeightMultiple, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineHeightMultiple)
 
-		let lineHeightMultipleProperty = Variable<CGFloat>(2.5)
+        let lineHeightMultipleProperty = BehaviorRelay<CGFloat>(value: 2.5)
 		lineHeightMultipleProperty.asObservable().bind(to: textPart.rx.lineHeightMultiple).disposed(by: bag)
 		XCTAssertEqual(textPart.lineHeightMultiple, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineHeightMultiple)
 
-		lineHeightMultipleProperty.value = 1.0
+		lineHeightMultipleProperty.accept(1.0)
 		XCTAssertEqual(textPart.lineHeightMultiple, (textPart.label.attributedText?.attribute(NSAttributedString.Key.paragraphStyle, at:0, effectiveRange:nil) as? NSParagraphStyle)?.lineHeightMultiple)
     }
 

--- a/Example/Tests/CardPartTitleViewTests.swift
+++ b/Example/Tests/CardPartTitleViewTests.swift
@@ -38,11 +38,11 @@ class CardPartTitleViewTests: XCTestCase {
 		titlePart.title = "hello"
 		XCTAssertEqual(titlePart.title, titlePart.label.text)
 		
-		let titleProperty = Variable("testing")
+        let titleProperty = BehaviorRelay(value: "testing")
 		titleProperty.asObservable().bind(to: titlePart.rx.title).disposed(by: bag)
 		XCTAssertEqual(titlePart.title, titlePart.label.text)
 		
-		titleProperty.value = "New Value"
+		titleProperty.accept("New Value")
 		XCTAssertEqual(titlePart.title, titlePart.label.text)
 	}
 	
@@ -56,11 +56,11 @@ class CardPartTitleViewTests: XCTestCase {
 		titlePart.titleFont = UIFont.boldSystemFont(ofSize: 50)
 		XCTAssertEqual(titlePart.titleFont, titlePart.label.font)
 
-		let fontProperty = Variable(UIFont.boldSystemFont(ofSize: 20))
+        let fontProperty = BehaviorRelay(value: UIFont.boldSystemFont(ofSize: 20))
 		fontProperty.asObservable().bind(to: titlePart.rx.titleFont).disposed(by: bag)
 		XCTAssertEqual(titlePart.titleFont, titlePart.label.font)
 
-		fontProperty.value = UIFont.boldSystemFont(ofSize: 30)
+		fontProperty.accept(UIFont.boldSystemFont(ofSize: 30))
 		XCTAssertEqual(titlePart.titleFont, titlePart.label.font)
     }
 
@@ -74,11 +74,11 @@ class CardPartTitleViewTests: XCTestCase {
 		titlePart.titleColor = UIColor.red
 		XCTAssertEqual(titlePart.titleColor, titlePart.label.textColor)
 
-		let titleColorProperty = Variable(UIColor.green)
+        let titleColorProperty = BehaviorRelay(value: UIColor.green)
 		titleColorProperty.asObservable().bind(to: titlePart.rx.titleColor).disposed(by: bag)
 		XCTAssertEqual(titlePart.titleColor, titlePart.label.textColor)
 
-		titleColorProperty.value = UIColor.blue
+		titleColorProperty.accept(UIColor.blue)
 		XCTAssertEqual(titlePart.titleColor, titlePart.label.textColor)
     }
 
@@ -89,11 +89,11 @@ class CardPartTitleViewTests: XCTestCase {
 		let titlePart = CardPartTitleView(type: .titleOnly)
 		XCTAssertNil(titlePart.menuTitle)
 		
-		let menuTitleProperty = Variable("hello")
+        let menuTitleProperty = BehaviorRelay(value: "hello")
 		menuTitleProperty.asObservable().bind(to: titlePart.rx.menuTitle).disposed(by: bag)
 		XCTAssertEqual(titlePart.menuTitle, "hello")
 		
-		menuTitleProperty.value = "New Value"
+		menuTitleProperty.accept("New Value")
 		XCTAssertEqual(titlePart.menuTitle, "New Value")
 	}
 
@@ -104,11 +104,11 @@ class CardPartTitleViewTests: XCTestCase {
 		let titlePart = CardPartTitleView(type: .titleOnly)
 		XCTAssertNil(titlePart.menuOptions)
 		
-		let menuOptionsProperty = Variable(["AAA", "BBB", "CCC"])
+        let menuOptionsProperty = BehaviorRelay(value: ["AAA", "BBB", "CCC"])
 		menuOptionsProperty.asObservable().bind(to: titlePart.rx.menuOptions).disposed(by: bag)
 		XCTAssertEqual(titlePart.menuOptions!, ["AAA", "BBB", "CCC"])
 		
-		menuOptionsProperty.value = ["111", "222"]
+		menuOptionsProperty.accept(["111", "222"])
 		XCTAssertEqual(titlePart.menuOptions!, ["111", "222"])
 	}
 
@@ -118,11 +118,11 @@ class CardPartTitleViewTests: XCTestCase {
 		
 		let titlePart = CardPartTitleView(type: .titleOnly)
 		
-		let buttonImageProperty = Variable("hello")
+        let buttonImageProperty = BehaviorRelay(value: "hello")
 		buttonImageProperty.asObservable().bind(to: titlePart.rx.menuButtonImageName).disposed(by: bag)
 		XCTAssertEqual(titlePart.menuButtonImageName, "hello")
 		
-		buttonImageProperty.value = "New Value"
+		buttonImageProperty.accept("New Value")
 		XCTAssertEqual(titlePart.menuButtonImageName, "New Value")
 	}
 

--- a/README.md
+++ b/README.md
@@ -155,15 +155,15 @@ class TestCardController: CardPartsViewController  {
 
 class TestViewModel {
 
-    var title = Variable("")
-    var text = Variable("")
+    var title = BehaviorRelay(value: "")
+    var text = BehaviorRelay(value: "")
 
     init() {
 
         // When these values change, the UI in the TestCardController
         // will automatically update
-        title.value = "Hello, world!"
-        text.value = "CardParts is awesome!"
+        title.accept("Hello, world!")
+        text.accept("CardParts is awesome!")
     }
 }
 ```
@@ -235,14 +235,14 @@ If the EditableCardTrait trait is added, the card will be rendered with an edit 
 The HiddenCardTrait trait requires the CardController to implement an isHidden variable:
 
 ```swift
-    var isHidden: Variable<Bool> { get }
+    var isHidden: BehaviorRelay<Bool> { get }
 ```
 
 The framework will then observe the isHidden variable so that whenever its value is changed the card will be hidden or shown based upon the new value. This allows the CardController to control its visibility by simply modifying the value of its isHidden variable.
 
 #### `ShadowCardTrait`
 
-The ShadowCardTrait protocol requires CardController to implement `shadowColor()`, `shadowRadius()`,  `shadowOpacity()` and `shadowOffset()`  methods.
+The ShadowCardTrait protocol requires CardController to implement `shadowColor()`, `shadowRadius()`, `shadowOpacity()` and `shadowOffset()` methods.
 
 ```swift
     func shadowColor() -> CGColor {
@@ -259,11 +259,11 @@ The ShadowCardTrait protocol requires CardController to implement `shadowColor()
     func shadowOpacity() -> Float {
         return 1.0
     }
-    
+
     func shadowOffset() -> CGSize {
     	return CGSize(width: 0, height: 5)
     }
- 
+
 ```
 
 <p align="center">
@@ -336,15 +336,15 @@ class TestCardController: CardPartsViewController  {
 
 class TestViewModel {
 
-    var title = Variable("")
-    var text = Variable("")
+    var title = BehaviorRelay(value: "")
+    var text = BehaviorRelay(value: "")
 
     init() {
 
         // When these values change, the UI in the TestCardController
         // will automatically update
-        title.value = "Hello, world!"
-        text.value = "CardParts is awesome!"
+        title.accept("Hello, world!")
+        text.accept("CardParts is awesome!")
     }
 }
 ```
@@ -663,8 +663,8 @@ viewModel.data.asObservable().bind(to: collectionViewCardPart.collectionView.rx.
 _Note: `viewModel.data` will be a reactive array of `SectionOfCustomStruct`_:
 
 ```swift
-typealias ReactiveSection = Variable<[SectionOfCustomStruct]>
-var data = ReactiveSection([])
+typealias ReactiveSection = BehaviorRelay<[SectionOfCustomStruct]>
+var data = ReactiveSection(value: [])
 ```
 
 #### `CardPartCollectionViewCardPartsCell`
@@ -899,15 +899,15 @@ Data binding is implemented using the RxSwift library (https://github.com/Reacti
 ```swift
 class TestViewModel {
 
-    var title = Variable("Testing")
-    var text = Variable("Card Part Text")
+    var title = BehaviorRelay(value: "Testing")
+    var text = BehaviorRelay(value: "Card Part Text")
 }
 ```
 
 Later when the view model's data has changed it can update its property by setting the value attribute of the property:
 
 ```swift
-title.value = “Hello”
+title.accept(“Hello”)
 ```
 
 The view controller can bind the view model property to a view:


### PR DESCRIPTION
Per issue #134 

The largest change is that `Variable` is replaced with `BehaviorRelay` which takes a value as a parameter.  Also, when changing its value we do not use `.value = ` anymore; instead it is `.accept()`. 