### PR TITLE
Fix preview size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![Platform](https://img.shields.io/cocoapods/p/CardParts.svg?style=flat)](http://cocoapods.org/pods/CardParts)
 
 <p align="left">
-    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintsights.gif" width="300" alt="MintSights by CardParts"/>
-    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintCardParts.gif" width="300" alt="CardParts in Mint"/>
-    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/turboCardParts.gif" width="300" alt="CardParts in Turbo"/>
+    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintsights.gif" width="290" alt="MintSights by CardParts"/>
+    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintCardParts.gif" width="290" alt="CardParts in Mint"/>
+    <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/turboCardParts.gif" width="290" alt="CardParts in Turbo"/>
 </p>
 
 CardParts - made with ❤️ by Intuit:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/cocoapods/l/CardParts.svg?style=flat)](http://cocoapods.org/pods/CardParts)
 [![Platform](https://img.shields.io/cocoapods/p/CardParts.svg?style=flat)](http://cocoapods.org/pods/CardParts)
 
-<p align="center">
+<p align="left">
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintsights.gif" width="300" alt="MintSights by CardParts"/>
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintCardParts.gif" width="300" alt="CardParts in Mint"/>
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/turboCardParts.gif" width="300" alt="CardParts in Turbo"/>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/cocoapods/l/CardParts.svg?style=flat)](http://cocoapods.org/pods/CardParts)
 [![Platform](https://img.shields.io/cocoapods/p/CardParts.svg?style=flat)](http://cocoapods.org/pods/CardParts)
 
-<p align="left">
+<p align="center">
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintsights.gif" width="290" alt="MintSights by CardParts"/>
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/mintCardParts.gif" width="290" alt="CardParts in Mint"/>
     <img src="https://raw.githubusercontent.com/Intuit/CardParts/master/images/turboCardParts.gif" width="290" alt="CardParts in Turbo"/>


### PR DESCRIPTION
Set preview items in row. Set width to `290`. See preview:

Before:

<img width="400" alt="Screenshot 2019-06-11 at 12 37 15" src="https://user-images.githubusercontent.com/10995774/59261395-0b7f4400-8c46-11e9-8bba-78f8677d4d3b.png">

After:

<img width="400" alt="Screenshot 2019-06-11 at 12 39 31" src="https://user-images.githubusercontent.com/10995774/59261399-0de19e00-8c46-11e9-8779-d75260d45fc8.png">



