### PR TITLE
Allow customization of cardCellMargins for individual CardsViewControllers

### DIFF
--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -43,6 +43,9 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
     let editButtonHeight : CGFloat = 50
     let editButtonWidth : CGFloat = 50
     let editButtonImage = "budgets_disclosure_icon"
+    
+    // allow customization of cardCellMargins for an individual CardsViewController; still default to theme
+    public var cardCellMargins : UIEdgeInsets = CardParts.theme.cardCellMargins
 
     var cardControllers = [CardInfo]()
 	var bag = DisposeBag()
@@ -83,21 +86,21 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
         
-        let newValue = view.bounds.width.rounded() - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right)
+        let newValue = view.bounds.width.rounded() - (cardCellMargins.left + cardCellMargins.right)
         if newValue != cardCellWidth.value {
             cardCellWidth.accept(newValue)
         }
     }
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        cardCellWidth.accept(size.width.rounded() - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right))
+        cardCellWidth.accept(size.width.rounded() - (cardCellMargins.left + cardCellMargins.right))
         invalidateLayout()
     }
     
     // functionality that happens when the view appears
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        let newValue = view.bounds.width.rounded() - (CardParts.theme.cardCellMargins.left + CardParts.theme.cardCellMargins.right)
+        let newValue = view.bounds.width.rounded() - (cardCellMargins.left + cardCellMargins.right)
         if newValue != cardCellWidth.value {
             cardCellWidth.accept(newValue)
         }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ CardParts - made with ❤️ by Intuit:
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
   - [CardsViewController](#cardsviewcontroller)
+    - [Custom Card Margins](#custom-card-margins)
   - [Card Traits](#card-traits)
     - [NoTopBottomMarginsCardTrait](#notopbottommarginscardtrait)
     - [TransparentCardTrait](#transparentcardtrait)
@@ -216,6 +217,23 @@ protocol CardController : NSObjectProtocol {
 
 The viewController() method must return the viewController that will be added as a child controller to the card cell. If the CardController is a UIViewController it can simply return self for this method.
 
+### Custom Card Margins
+
+By default, the margins of your `CardsViewController` will match the theme's `cardCellMargins` property. You can change the margins for all `CardsViewController`s in your application by applying a new [theme](#themes) or setting `CardParts.theme.cardCellMargins = UIEdgeInsets(...)`. Alternatively, if you want to change the margins for just one `CardsViewController`, you can set the `cardCellMargins` property of that `CardsViewController`. This property will default to use the theme's margins if you do not specify a new value for it. Changing this value should be done in the `init` of your custom `CardsViewController`, but must occur after `super.init` because it is changing a property of the super class. For example:
+
+```swift
+class MyCardsViewController: CardsViewController {
+
+	init() {
+		// set up properties
+		super.init(nibName: nil, bundle: nil)
+		self.cardCellMargins = UIEdgeInsets(/* custom card margins */)
+	}
+	
+	...
+}
+```
+
 ## Card Traits
 
 The Card Parts framework defines a set of traits that can be used to modify the appearance and behavior of cards. These traits are implemented as protocols and protocol extensions. To add a trait to a card simply add the trait protocol to the CardController definition. For example:
@@ -345,7 +363,8 @@ Use this protocol to add border color and border width for the card, implement `
 
 ## `CardPartsViewController`
 
-CardPartsViewController implements the CardController protocol and builds its card UI by displaying one or more card part views using an MVVM pattern that includes automatic data binding. Each CardPartsViewController displays a list of CardPartView as its subviews. Each CardPartView renders as a row in the card. The CardParts framework implements several different types of CardPartView that display basic views, such as title, text, image, button, separator, etc. All CardPartView implemented by the framework are already styled to correctly match the applied themes UI guidelines.
+CardPartsViewController implements the CardController protocol and builds its card UI by displaying one or more card part views using an MVVM pattern that includes automatic data binding. Each CardPartsViewController displays a list of CardPartView as its subviews. Each CardPartView renders as a row in the card. The CardParts framework implements several different types of CardPartView that display basic views, such as title, text, image, button, separator, etc. All CardPartView implemented by the framework are already styled to correctly match the applied 
+s UI guidelines.
 
 In addition to the card parts, a CardPartsViewController also uses a view model to expose data properties that are bound to the card parts. The view model should contain all the business logic for the card, thus keeping the role of the CardPartsViewController to just creating its view parts and setting up bindings from the view model to the card parts. A simple implementation of a CardPartsViewController based card might look like the following:
 


### PR DESCRIPTION
add field in CardsViewController to allow customization of cardCellMargins


## Before you make a Pull Request, read the important guidelines:

## Issue Link :link:
 <ul>
   <li> Is this a bug fix or a feature? </li>
   <li> Does it break any existing functionality?</li>
</ul>

## Goals of this PR :tada:
 <ul>
   <li> Why is the change important? </li>
   <li> What does this fix? </li>
   <li> How far has it been tested? </li>
 </ul>
 
## How Has This Been Tested :mag:

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: </li>
 <li> Device/Simulator </li>
 <li> iOS version || MacOSX version</li>
</ul>

## Things to check on :dart:


 - [ ] My Pull Request code follows the coding standards and styles of the project 
 - [ ] I have worked on unit tests and reviewed my code to the best of my ability 
 - [ ] I have used comments to make other coders understand my code better 
 - [ ] My changes are good to go without any warnings 
 - [ ] I have added unit tests both for the happy and sad path 
 - [ ] All of my unit tests pass successfully before pushing the PR 
 - [ ] I have made sure all dependent downstream changes impacted by my PR are working 


  
