### PR TITLE
Adding a capability to load specific cards added to collection view

### DIFF
--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -131,7 +131,7 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
     /// - Parameters:
     ///   - cards: list of cards all the cards
     ///   - indexPaths: indexPath for the cards which needs to be reloaded.
-    public func loadSpecifcCards(cards: [CardController] , indexPaths: [IndexPath]) {
+    public func loadSpecificCards(cards: [CardController] , indexPaths: [IndexPath]) {
         setCardControllers(cards: cards)
         registerCells(cards: cards)
         collectionView.reloadItems(at: indexPaths)

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -126,6 +126,13 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
 		collectionView.reloadData()
 		collectionView.collectionViewLayout.invalidateLayout()
 	}
+    
+    public func loadSpecifcCards(cards: [CardController] , indexPaths: [IndexPath]) {
+        setCardControllers(cards: cards)
+        registerCells(cards: cards)
+        collectionView.reloadItems(at: indexPaths)
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
 
 	private func setCardControllers(cards: [CardController]) {
 		var cardInfos: [CardInfo] = []

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -127,6 +127,10 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
 		collectionView.collectionViewLayout.invalidateLayout()
 	}
     
+    /// Method provides option to reload cards based on the indexPaths row and sections of collectionView.
+    /// - Parameters:
+    ///   - cards: list of cards all the cards
+    ///   - indexPaths: indexPath for the cards which needs to be reloaded.
     public func loadSpecifcCards(cards: [CardController] , indexPaths: [IndexPath]) {
         setCardControllers(cards: cards)
         registerCells(cards: cards)


### PR DESCRIPTION
**Description :** 

Assume for eg: We have more than 2+ Cards, We want to reload only certain cards based on some criteria.

## Issue Link :link:
 <ul>
   <li> Feature </li>
   <li> None</li>
</ul>

## Goals of this PR :tada:
 <ul>
   <li> This provides a capability to load specifis cards. </li>
   <li> None </li>
   <li> Tested </li>
 </ul>
 
## How Has This Been Tested :mag:

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: 11.3 </li>
 <li> iPhone 11 Pro Max </li>
 <li> iOS 13.3 </li>
</ul>

## Things to check on :dart:


 - [ ] My Pull Request code follows the coding standards and styles of the project 
 - [ ] I have worked on unit tests and reviewed my code to the best of my ability 
 - [ ] I have used comments to make other coders understand my code better 
 - [ ] My changes are good to go without any warnings 
 - [ ] I have added unit tests both for the happy and sad path 
 - [ ] All of my unit tests pass successfully before pushing the PR 
 - [ ] I have made sure all dependent downstream changes impacted by my PR are working 


  
