### PR TITLE
Update RxCocoa/Swift/DataSource/Gesture

### DIFF
--- a/CardParts.podspec
+++ b/CardParts.podspec
@@ -28,9 +28,9 @@ CardParts is an iOS Card UI framework that uses MVVM and automatic data binding 
   s.swift_version = '5.0'
   s.source_files = 'CardParts/src/**/*'
 
-  s.dependency 'RxSwift', '~> 4.5'
-  s.dependency 'RxCocoa', '~> 4.5'
-  s.dependency 'RxDataSources', '~> 3.1'
-  s.dependency 'RxGesture', '~> 2.2'
+  s.dependency 'RxSwift', '~> 5.0'
+  s.dependency 'RxCocoa', '~> 5.0'
+  s.dependency 'RxDataSources', '~> 4.0'
+  s.dependency 'RxGesture', '~> 3.0'
 
 end

--- a/Example/CardParts/CardPartMapViewCardController.swift
+++ b/Example/CardParts/CardPartMapViewCardController.swift
@@ -40,7 +40,7 @@ class CardPartMapViewCardController: CardPartsViewController {
     private func setupBindings() {
         cardPartTextField.rx.text
             .distinctUntilChanged()
-            .debounce(1, scheduler: MainScheduler.instance)
+            .debounce(.seconds(1), scheduler: MainScheduler.instance)
             .filter { $0 != nil && !$0!.isEmpty }
             .flatMap { self.viewModel.getLocation(from: $0!)}
             .catchError({ error -> Observable<CLLocation> in


### PR DESCRIPTION
This fixes #239 and #64 

It seems like the only thing that actually needed to be changed was the dependency lines. I recommend an additional PR to bump the Pod version.

I ran this against a project using RxSwift/RxCocoa 5.1.1, Swift 5, and iOS 13 with successful results