### PR TITLE
Adding dynamic support of height in CardPartPagedView

### DIFF
--- a/CardParts/src/Classes/Card Parts/CardPartPagedView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartPagedView.swift
@@ -34,11 +34,16 @@ public class CardPartPagedView: UIView, CardPartView {
 		}
 	}
 	
+	public var height: CGFloat {
+		didSet{
+			self.updateConstraints()
+		}
+	}
+	
 	public var delegate: CardPartPagedViewDelegate?
 	
 	fileprivate var pageControl: UIPageControl
 	fileprivate var scrollView: UIScrollView
-	fileprivate var height: CGFloat
 	
 	public init(withPages pages: [CardPartStackView], andHeight height: CGFloat) {
 		


### PR DESCRIPTION
## Before you make a Pull Request, read the important guidelines:

## Issue Link :link:
This is an additional capability in CardPartPagedView to dynamically update the height of the view after it has already been instantiated. And it will not break any existing capability.

## Goals of this PR :tada:
We are using CardParts in Mint and specifically for bills overview card we are using CardPartPagedView component [which is similar to pageViewController functionality i.e. provides the ability to have multiple scrollable views in our case horizontal].
We have a requirement of dynamically changing the height of this view when state of this card changes from empty state to data state. [ An empty state is when a user does not have any bills attached or the bills are currently been fetched. Data state is when user’s bills have been fetched and ready for display ]. When the bills are in empty state lets say the height of the bills overview should be 400 and when the bills have been fetched we have to resize the bills overview card to 350.

## How Has This Been Tested :mag:
We have tested this PR with Mint app and the changes works fine everywhere.


## Things to check on :dart:


 - [x] My Pull Request code follows the coding standards and styles of the project 
 - [x] I have worked on unit tests and reviewed my code to the best of my ability 
 - [ ] I have used comments to make other coders understand my code better (NA)
 - [x] My changes are good to go without any warnings
 - [ ] I have added unit tests both for the happy and sad path (NA)
 - [ ] All of my unit tests pass successfully before pushing the PR (NA)
 - [x] I have made sure all dependent downstream changes impacted by my PR are working 


  
