### PR TITLE
Fix wrong layout on iPad modal presentation when the view controller frame is changed

### DIFF
--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -86,6 +86,11 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[collectionView]|", options: [], metrics: nil, views: ["collectionView" : collectionView!]))
         
+        // immediate layout pass to ensure collection view layout reflects the latest frame size
+        cardCellWidth.distinctUntilChanged().asObservable().subscribe(onNext: { [weak self] _ in
+            self?.invalidateLayout()
+        }).disposed(by: bag)
+        
         let newValue = view.bounds.width.rounded() - (cardCellMargins.left + cardCellMargins.right)
         if newValue != cardCellWidth.value {
             cardCellWidth.accept(newValue)
@@ -94,7 +99,6 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         cardCellWidth.accept(size.width.rounded() - (cardCellMargins.left + cardCellMargins.right))
-        invalidateLayout()
     }
     
     // functionality that happens when the view appears


### PR DESCRIPTION
## Before you make a Pull Request, read the important guidelines:

## Issue Link :link:
 <ul>
   <li> Is this a bug fix or a feature? Bug fix</li>
   <li> Does it break any existing functionality? No</li>
</ul>

## Goals of this PR :tada:

- Why is the change important? A view frame change in the `CardsViewController` should reflect the latest size in the layout, specifically recalculating the sizing of the cells of the flow layout if the `cardCellWidth` changes.
- What does this fix? The collection view layout will recalculate, with an immediate layout pass, upon `cardCellWidth` changes such as when a `CardsViewController` is presented as a formSheet on an iPad.
- How far has it been tested? Manual testing 
 
## How Has This Been Tested :mag:

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

- Xcode version: **11.5** 
- Device/Simulator: **iPad Pro (12.9-inch) (4th generation)** 
- iOS version: **13.5** || MacOSX version: **10.15.5** 

## Things to check on :dart:


 - [x] My Pull Request code follows the coding standards and styles of the project 
 - [ ] I have worked on unit tests and reviewed my code to the best of my ability 
 - [x] I have used comments to make other coders understand my code better 
 - [x] My changes are good to go without any warnings 
 - [ ] I have added unit tests both for the happy and sad path 
 - [ ] All of my unit tests pass successfully before pushing the PR 
 - [x] I have made sure all dependent downstream changes impacted by my PR are working 


  
