### PR TITLE
Added SPM support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CardParts/src/Classes/Card Parts/CardPartBarView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartBarView.swift
@@ -6,7 +6,12 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartCenteredView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartCenteredView.swift
@@ -5,7 +5,11 @@
 //  Created by Tumer, Deniz on 6/20/18.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 public class CardPartCenteredView: UIView, CardPartView {
     public var margins: UIEdgeInsets = CardParts.theme.cardPartMargins

--- a/CardParts/src/Classes/Card Parts/CardPartCollectionViewCardPartsCell.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartCollectionViewCardPartsCell.swift
@@ -5,7 +5,11 @@
 //  Created by Roossin, Chase on 3/7/18.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 open class CardPartCollectionViewCardPartsCell : UICollectionViewCell {
 

--- a/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
@@ -141,6 +141,8 @@ public class CardPartConfettiView: UIView, CardPartView {
 }
 
 private extension Bundle {
+
+    /// Gets the correct Bundle for cenfetti images based on the environment.
     static var confetti: Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module

--- a/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
@@ -37,7 +37,7 @@ public class CardPartConfettiView: UIView, CardPartView {
         }
     }
     
-    public var confettiImages = [UIImage(named: "confetti", in: Bundle(for: CardPartConfettiView.self),compatibleWith: nil)] as? [UIImage]
+    public var confettiImages = [UIImage(named: "confetti", in: Bundle.confetti,compatibleWith: nil)] as? [UIImage]
     
     //A layer that emits, animates, and renders a particle system.
     var emitter: CAEmitterLayer = CAEmitterLayer()
@@ -127,15 +127,25 @@ public class CardPartConfettiView: UIView, CardPartView {
     private func image(for type: ConfettiType, index: Int = 0) -> UIImage? {
         switch type {
         case .diamond:
-            return UIImage(named: "diamond", in: Bundle(for: CardPartConfettiView.self), compatibleWith: nil)
+            return UIImage(named: "diamond", in: Bundle.confetti, compatibleWith: nil)
         case .star:
-            return UIImage(named: "star", in: Bundle(for: CardPartConfettiView.self), compatibleWith: nil)
+            return UIImage(named: "star", in: Bundle.confetti, compatibleWith: nil)
         case let .image(customImage):
             return customImage
         case .mixed:
             return confettiImages?[index]
         case .confetti:
-             return UIImage(named: "confetti", in: Bundle(for: CardPartConfettiView.self), compatibleWith: nil)
+            return UIImage(named: "confetti", in: Bundle.confetti, compatibleWith: nil)
         }
+    }
+}
+
+private extension Bundle {
+    static var confetti: Bundle {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: CardPartConfettiView.self)
+        #endif
     }
 }

--- a/CardParts/src/Classes/Card Parts/CardPartMultiSliderView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartMultiSliderView.swift
@@ -5,7 +5,12 @@
 //  Created by bcarreon1  on 1/30/20.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartOrientedView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartOrientedView.swift
@@ -5,7 +5,11 @@
 //  Created by Tumer, Deniz on 6/13/18.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 public enum Orientation {
     case top

--- a/CardParts/src/Classes/Card Parts/CardPartSeparatorView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartSeparatorView.swift
@@ -6,7 +6,12 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartSliderView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartSliderView.swift
@@ -5,7 +5,12 @@
 //  Created by Kier, Tom on 12/9/17.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartSpacerView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartSpacerView.swift
@@ -6,7 +6,12 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartSwitchView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartSwitchView.swift
@@ -5,6 +5,10 @@
 //  Created by bcarreon1  on 2/25/20.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 public class CardPartSwitchView: UISwitch, CardPartView {
     public var margins: UIEdgeInsets = CardParts.theme.cardPartMargins
 }

--- a/CardParts/src/Classes/Card Parts/CardPartTextField.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTextField.swift
@@ -5,8 +5,12 @@
 //  Created by Kier, Tom on 12/14/17.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
-import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
@@ -47,7 +47,7 @@ public class CardPartTitleView : UIView, CardPartView {
 	public var menuButtonImageName: String = "arrowdown" {
 		didSet {
 			if type == .titleWithMenu || type == .titleWithActionableButton {
-                menuButtonImage = UIImage(named: menuButtonImageName, in: Bundle(for: CardPartTitleView.self), compatibleWith: nil)
+                menuButtonImage = UIImage(named: menuButtonImageName, in: Bundle.title, compatibleWith: nil)
 			}
 		}
 	}
@@ -80,7 +80,7 @@ public class CardPartTitleView : UIView, CardPartView {
                 if let image = menuButtonImage {
                     button.setImage(image, for: .normal)
                 } else {
-                    button.setImage(UIImage(named: menuButtonImageName, in: Bundle(for: CardPartTitleView.self), compatibleWith: nil), for: .normal)
+                    button.setImage(UIImage(named: menuButtonImageName, in: Bundle.title, compatibleWith: nil), for: .normal)
                 }
 				button.addTarget(self, action: #selector(menuButtonTapped), for: UIControl.Event.touchUpInside)
 				addSubview(button)
@@ -92,7 +92,7 @@ public class CardPartTitleView : UIView, CardPartView {
                 if let image = menuButtonImage {
                     button.setImage(image, for: .normal)
                 } else {
-                    button.setImage(UIImage(named: menuButtonImageName, in: Bundle(for: CardPartTitleView.self), compatibleWith: nil), for: .normal)
+                    button.setImage(UIImage(named: menuButtonImageName, in: Bundle.title, compatibleWith: nil), for: .normal)
                 }
 				button.addTarget(self, action: #selector(actionableMenuTapped), for: UIControl.Event.touchUpInside)
 				addSubview(button)
@@ -201,5 +201,15 @@ extension Reactive where Base: CardPartTitleView {
         return Binder(self.base) { (titleView, menuButtonImage) -> () in
             titleView.menuButtonImage = menuButtonImage
         }
+    }
+}
+
+private extension Bundle {
+    static var title: Bundle {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: CardPartTitleView.self)
+        #endif
     }
 }

--- a/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTitleView.swift
@@ -205,6 +205,8 @@ extension Reactive where Base: CardPartTitleView {
 }
 
 private extension Bundle {
+
+    /// Gets the correct Bundle for the `arrowdown` image based on the environment.
     static var title: Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module

--- a/CardParts/src/Classes/Card Parts/CardPartTriangleView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartTriangleView.swift
@@ -5,7 +5,11 @@
 //  Created by Venkatnarayansetty, Badarinath on 9/19/19.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 class CardPartTriangleView: UIView,CardPartView {
         

--- a/CardParts/src/Classes/Card Parts/CardPartVerticalSeparatorView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartVerticalSeparatorView.swift
@@ -6,7 +6,12 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
+
 import RxSwift
 import RxCocoa
 

--- a/CardParts/src/Classes/CardPartTableViewCardPartsCell.swift
+++ b/CardParts/src/Classes/CardPartTableViewCardPartsCell.swift
@@ -6,7 +6,11 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 open class CardPartTableViewCardPartsCell : UITableViewCell {
 		

--- a/CardParts/src/Classes/CardPartsFullScreenViewController.swift
+++ b/CardParts/src/Classes/CardPartsFullScreenViewController.swift
@@ -6,7 +6,11 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 open class CardPartsFullScreenViewController: CardPartsViewController {
 	

--- a/CardParts/src/Classes/CardPartsTheme.swift
+++ b/CardParts/src/Classes/CardPartsTheme.swift
@@ -5,7 +5,11 @@
 //  Created by Kier, Tom on 12/7/17.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 public protocol CardPartsTheme {
     

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -248,7 +248,7 @@ open class CardsViewController : UIViewController, UICollectionViewDataSource, U
             }.disposed(by: bag)
 			if getEditModeForIndexPath(indexPath: indexPath) {
 				let editButton = UIButton(frame: CGRect(x: view.bounds.size.width - editButtonOffset - editButtonWidth, y: 0, width: editButtonWidth, height: editButtonHeight))
-				editButton.setImage(UIImage(named: editButtonImage, in: Bundle(for: CardsViewController.self), compatibleWith: nil), for: .normal)
+                editButton.setImage(UIImage(named: editButtonImage, in: Bundle.controller, compatibleWith: nil), for: .normal)
 				editButton.addTargetClosure { _ in
 					if let editibalCardTrait = cardController as? EditableCardTrait {
 						editibalCardTrait.onEditButtonTap()
@@ -469,5 +469,15 @@ extension CardsViewController {
     // calls for visibility of card when the scroll view scrolls
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         notifyCardsVisibility()
+    }
+}
+
+private extension Bundle {
+    static var controller: Bundle {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: CardsViewController.self)
+        #endif
     }
 }

--- a/CardParts/src/Classes/CardsViewController.swift
+++ b/CardParts/src/Classes/CardsViewController.swift
@@ -473,6 +473,8 @@ extension CardsViewController {
 }
 
 private extension Bundle {
+
+    /// Gets the correct Bundle for the `budgets_disclosure_icon` image based on the environment.
     static var controller: Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module

--- a/CardParts/src/Delegates/CardVisibilityDelegate.swift
+++ b/CardParts/src/Delegates/CardVisibilityDelegate.swift
@@ -5,6 +5,10 @@
 //  Created by Tumer, Deniz on 5/23/18.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 /*
  * This protocol handles passing data about the visibility of a card
  * from an instance of a CardsViewController to the card itself

--- a/CardParts/src/Extensions/Date.swift
+++ b/CardParts/src/Extensions/Date.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Intuit, Inc. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import Foundation
+#endif
+
 enum DateFormat : String {
     case Date = "yyyy'-'MM'-'dd'", DateAndTime = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ", CreditDateAndTime = "yyyy-MM-dd'T'HH:mm:ss.sssZ", CreditShortDateAndTime = "MMMM yyyy", DateSlashes  = "MM/dd/yyyy", abbreviatedMonth = "MMM YYYY", abbreviatedMonthIncludeDate = "MMM d, YYYY"
 }

--- a/CardParts/src/Extensions/NSObjectProtocol.swift
+++ b/CardParts/src/Extensions/NSObjectProtocol.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Intuit, Inc. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import Foundation
+#endif
+
 extension NSObjectProtocol {
     var className: String {
         return String(describing: type(of: self))

--- a/CardParts/src/Extensions/UIButton.swift
+++ b/CardParts/src/Extensions/UIButton.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Intuit, Inc. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 typealias UIButtonTargetClosure = (UIButton) -> ()
 
 extension UIButton {

--- a/CardParts/src/Extensions/UIColor.swift
+++ b/CardParts/src/Extensions/UIColor.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Intuit, Inc. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 extension UIColor {
     
     static var turboGenericGreyTextColor : UIColor {get{return UIColor.color(169, green: 169, blue: 169)}}

--- a/CardParts/src/Extensions/UIFont.swift
+++ b/CardParts/src/Extensions/UIFont.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Intuit, Inc. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 enum FontSize: Int {
     case ultrabig = 48, header = 36, xx_Large = 28, x_Large = 24, large = 17, medium = 16, normal = 14, small = 12, x_Small = 10
 }

--- a/CardParts/src/Extensions/UIView.swift
+++ b/CardParts/src/Extensions/UIView.swift
@@ -5,6 +5,10 @@
 //  Created by bcarreon1 on 1/30/20.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#endif
+
 extension UIView {
     func roundCorners(_ corners: CACornerMask, radius: CGFloat){
         if #available(iOS 11.0, *) {

--- a/CardParts/src/Utilities/CardUtils.swift
+++ b/CardParts/src/Utilities/CardUtils.swift
@@ -5,7 +5,11 @@
 //  Created by Tumer, Deniz on 5/23/18.
 //
 
+#if SWIFT_PACKAGE
+import UIKit
+#else
 import Foundation
+#endif
 
 /*
  * Defines utility methods for cards.

--- a/Example/Tests/CardPartImageViewTests.swift
+++ b/Example/Tests/CardPartImageViewTests.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Mint.com. All rights reserved.
 //
 
+@testable import CardParts
+
 import XCTest
 import RxSwift
 import RxCocoa
@@ -23,7 +25,25 @@ class CardPartImageViewTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
+    func testAssetResources() {
+        #if SWIFT_PACKAGE
+        let arrowdown = UIImage(named: "arrowdown", in: Bundle.module, compatibleWith: nil)
+        let budgets = UIImage(named: "budgets_disclosure_icon", in: Bundle.module, compatibleWith: nil)
+        let confetti = UIImage(named: "confetti", in: Bundle.module, compatibleWith: nil)
+        let diamond = UIImage(named: "diamond", in: Bundle.module, compatibleWith: nil)
+        let star = UIImage(named: "star", in: Bundle.module, compatibleWith: nil)
+        let triangle = UIImage(named: "triangle", in: Bundle.module, compatibleWith: nil)
+
+        XCTAssertNotNil(arrowdown)
+        XCTAssertNotNil(budgets)
+        XCTAssertNotNil(confetti)
+        XCTAssertNotNil(diamond)
+        XCTAssertNotNil(star)
+        XCTAssertNotNil(triangle)
+        #endif
+    }
+
 	func testMenuOptionsProperty() {
 		
 		let bag = DisposeBag()

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxDataSources",
+        "repositoryURL": "https://github.com/RxSwiftCommunity/RxDataSources.git",
+        "state": {
+          "branch": null,
+          "revision": "a18cee01c9ee55f04d0c7eb15c77a96c3648c88e",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "package": "RxGesture",
+        "repositoryURL": "https://github.com/RxSwiftCommunity/RxGesture.git",
+        "state": {
+          "branch": null,
+          "revision": "867f176b6695829e350fafc00b5a849bb46a1857",
+          "version": "3.0.3"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "CardParts",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(name: "CardParts", targets: ["CardParts"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0"),
+        .package(url: "https://github.com/RxSwiftCommunity/RxDataSources.git", from: "4.0.0"),
+        .package(url: "https://github.com/RxSwiftCommunity/RxGesture.git", from: "3.0.0")
+    ],
+    targets: [
+        .target(
+            name: "CardParts",
+            dependencies: [
+                .byName(name: "RxSwift"),
+                .product(name: "RxCocoa", package: "RxSwift"),
+                .byName(name: "RxDataSources"),
+                .byName(name: "RxGesture")
+            ],
+            path: "CardParts",
+            resources: [
+                .process("Assets/icons.xcassets")
+            ]
+        ),
+        .testTarget(
+            name: "CardPartsTests",
+            dependencies: ["CardParts"],
+            path: "Example/Tests"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
                 .byName(name: "RxGesture")
             ],
             path: "CardParts",
+            exclude: ["Example"],
             resources: [
                 .process("Assets/icons.xcassets")
             ]


### PR DESCRIPTION
## Issue Link https://github.com/intuit/CardParts/issues/172
Closes https://github.com/intuit/CardParts/issues/172

## Goals of this PR :tada:
Adds support for the Swift Package Manager, as an alternative to CocoaPods.
 
## How Has This Been Tested :mag:
Adds a single test `CardPartImageViewTests.testAssetResources` to check that resources are properly loaded in an SPM environment.

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: 12.0 (12A7209)</li>
 <li> Device/Simulator: N/A</li>
 <li> iOS version: N/A</li>
</ul>

## Things to check on :dart:


 - [x] My Pull Request code follows the coding standards and styles of the project 
 - [x] I have worked on unit tests and reviewed my code to the best of my ability 
 - [x] I have used comments to make other coders understand my code better 
 - [ ] My changes are good to go without any warnings 
 - [x] I have added unit tests both for the happy and sad path 
 - [x] All of my unit tests pass successfully before pushing the PR 
 - [x] I have made sure all dependent downstream changes impacted by my PR are working 


  
