### PR TITLE
Add beginTime to emitter to fix emitter position

### DIFF
--- a/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
+++ b/CardParts/src/Classes/Card Parts/CardPartConfettiView.swift
@@ -55,6 +55,7 @@ public class CardPartConfettiView: UIView, CardPartView {
         emitter.emitterPosition = CGPoint(x: frame.size.width / 2.0, y: 0)
         emitter.emitterShape = shape
         emitter.emitterSize = CGSize(width: frame.size.width, height: 1)
+        emitter.beginTime = CACurrentMediaTime()
         
         //construct the cells
         var cells = [CAEmitterCell]()


### PR DESCRIPTION
## Before you make a Pull Request, read the important guidelines:

## Issue Link :link:
 <ul>
   <li> Is this a bug fix or a feature? Bug Fix</li>
   <li> Does it break any existing functionality? No, although it may change some existing functionality (to work how it's supposed to work)</li>
</ul>

## Goals of this PR :tada:
 <ul>
   <li> Why is the change important? Prevents confetti from appearing in the middle of the screen instead of at the emitter point</li>
   <li> What does this fix? See videos below (note in the before confetti appears elsewhere on the screen at first instead of just at the emitter point</li>
   <li> How far has it been tested? Enough to see that it works 🙂 . I came to this solution through the following excerpt from a NSHipster article (https://nshipster.com/caemitterlayer/):

> The central problem is that Core Animation operates on its own timeline, which doesn’t always comport with our own understanding of time.
> For instance, if you neglect to initialize the beginTime of the emitter layer with CACurrentMediaTime() right before it’s displayed, it’ll render with the wrong time space.</li>

 </ul>

Before: 
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/26018831/109080420-5f012200-76b5-11eb-90be-0c22b00017a5.gif)



After:
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/26018831/109080387-4a248e80-76b5-11eb-8845-c92686f4936b.gif)


 
## How Has This Been Tested :mag:

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: </li>
 <li> Device/Simulator </li>
 <li> iOS version || MacOSX version</li>
</ul>

## Things to check on :dart:


 - [ ] My Pull Request code follows the coding standards and styles of the project 
 - [ ] I have worked on unit tests and reviewed my code to the best of my ability 
 - [ ] I have used comments to make other coders understand my code better 
 - [ ] My changes are good to go without any warnings 
 - [ ] I have added unit tests both for the happy and sad path 
 - [ ] All of my unit tests pass successfully before pushing the PR 
 - [ ] I have made sure all dependent downstream changes impacted by my PR are working 


  
