### PR TITLE
Make the thumb shadow of CardPartMultiSlider configurable

### DIFF
--- a/CardParts.podspec
+++ b/CardParts.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CardParts'
-  s.version          = '3.4.0'
+  s.version          = '3.5.0'
   s.platform         = :ios
   s.summary          = 'iOS Card UI framework.'
 

--- a/CardParts/src/Classes/CardPartMultiSlider+Internal.swift
+++ b/CardParts/src/Classes/CardPartMultiSlider+Internal.swift
@@ -141,18 +141,17 @@ extension CardPartMultiSlider {
     private func addThumbView() {
         let i = thumbViews.count
         let thumbView = UIImageView(image: thumbImage ?? defaultThumbImage)
-        thumbView.addShadow()
         thumbViews.append(thumbView)
         slideView.addConstrainedSubview(thumbView, constrain: NSLayoutConstraint.Attribute.center(in: orientation).perpendicularCenter)
         positionThumbView(i)
         thumbView.blur(disabledThumbIndices.contains(i))
         addValueLabel(i)
-        updateThumbViewShadowVisibility()
+        updateThumbViewShadow()
     }
 
-    func updateThumbViewShadowVisibility() {
+    func updateThumbViewShadow() {
         thumbViews.forEach {
-            $0.layer.shadowOpacity = showsThumbImageShadow ? 0.25 : 0
+            $0.addShadow(color: thumbShadowColor, opacity: showsThumbImageShadow ? thumbShadowOpacity : 0, offset: thumbShadowOffset, radius: thumbShadowRadius)
         }
     }
 

--- a/CardParts/src/Classes/CardPartMultiSlider.swift
+++ b/CardParts/src/Classes/CardPartMultiSlider.swift
@@ -101,10 +101,30 @@ open class CardPartMultiSlider: UIControl {
             invalidateIntrinsicContentSize()
         }
     }
-
+    
+    public dynamic var thumbShadowColor: UIColor = .gray {
+        didSet {
+            updateThumbViewShadow()
+        }
+    }
+    public dynamic var thumbShadowOpacity: Float = 0.25 {
+        didSet {
+            updateThumbViewShadow()
+        }
+    }
+    public dynamic var thumbShadowOffset: CGSize = CGSize(width: 0, height: 4) {
+        didSet {
+            updateThumbViewShadow()
+        }
+    }
+    public dynamic var thumbShadowRadius: CGFloat = 2 {
+        didSet {
+            updateThumbViewShadow()
+        }
+    }
     public dynamic var showsThumbImageShadow: Bool = true {
         didSet {
-            updateThumbViewShadowVisibility()
+            updateThumbViewShadow()
         }
     }
 

--- a/CardParts/src/Extensions/CardPartMultiSliderExtensions.swift
+++ b/CardParts/src/Extensions/CardPartMultiSliderExtensions.swift
@@ -67,11 +67,11 @@ extension UIView {
         }
     }
 
-    func addShadow() {
-        layer.shadowColor = UIColor.gray.cgColor
-        layer.shadowOpacity = 0.25
-        layer.shadowOffset = CGSize(width: 0, height: 4)
-        layer.shadowRadius = 0.5
+    func addShadow(color: UIColor, opacity: Float, offset: CGSize, radius: CGFloat) {
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = opacity
+        layer.shadowOffset = offset
+        layer.shadowRadius = radius
     }
 }
 

--- a/Example/CardParts/CardPartMultiSliderViewCardController.swift
+++ b/Example/CardParts/CardPartMultiSliderViewCardController.swift
@@ -27,6 +27,12 @@ class CardPartMultiSliderViewCardController: CardPartsViewController {
         cardPartMultiSliderView.outerTrackColor = .gray
         cardPartMultiSliderView.tintColor = .blue
         
+        cardPartMultiSliderView.thumbImage = UIImage(named: "star")
+        cardPartMultiSliderView.thumbShadowColor = .black
+        cardPartMultiSliderView.thumbShadowOpacity = 0.25
+        cardPartMultiSliderView.thumbShadowOffset = CGSize(width: 0, height: 2)
+        cardPartMultiSliderView.thumbShadowRadius = 6
+        
         setupCardParts([cardPartTextView, cardPartMultiSliderView])
     }
 }


### PR DESCRIPTION

![Simulator Screen Shot - iPhone 11 Pro - 2021-04-08 at 12 45 53](https://user-images.githubusercontent.com/26018831/114087271-87f60480-9868-11eb-8499-e738ab2c94ec.png)

## Before you make a Pull Request, read the important guidelines:

## Issue Link :link:
 <ul>
   <li> Is this a bug fix or a feature? **Feature!** </li>
   <li> Does it break any existing functionality? **No** </li>
</ul>

## Goals of this PR :tada:
 <ul>
   <li> Why is the change important? **Allows custom shadows on the CardPartMultiSlider thumb images** </li>
   <li> What does this fix? </li>
   <li> How far has it been tested? </li>
 </ul>
 
## How Has This Been Tested :mag:

Manually tested shadows with different configurations to confirm that it was having the desired effect

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: 12.4</li>
 <li> Device/Simulator iPhone 11 Pro</li>
 <li> iOS version 14.4 || MacOSX version</li>
</ul>

## Things to check on :dart:


 - [x] My Pull Request code follows the coding standards and styles of the project 
 - [x] I have worked on unit tests and reviewed my code to the best of my ability 
 - [x] I have used comments to make other coders understand my code better 
 - [x] My changes are good to go without any warnings 
 - [x] I have added unit tests both for the happy and sad path 
 - [x] All of my unit tests pass successfully before pushing the PR 
 - [x] I have made sure all dependent downstream changes impacted by my PR are working 


  
