### PR TITLE
Update Array `safeValue(at:)` behavior for negative index

### DIFF
--- a/CardParts/src/Extensions/Array.swift
+++ b/CardParts/src/Extensions/Array.swift
@@ -9,11 +9,10 @@ import Foundation
 
 extension Array {
     func safeValue(at index: Int) -> Element? {
-        if index < self.count {
-            return self[index]
-        } else {
+        guard index >= 0, index < count else {
             return nil
         }
+        return self[index]
     }
 }
 

--- a/CardParts/src/Extensions/Array.swift
+++ b/CardParts/src/Extensions/Array.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 extension Array {
+    /// read an array element at a given `index` safely
+    /// - Parameter index: the index of the element to read
+    /// - Returns: array element at a given `index`. `nil` if index is out of range
     func safeValue(at index: Int) -> Element? {
         guard index >= 0, index < count else {
             return nil

--- a/Example/CardParts.xcodeproj/project.pbxproj
+++ b/Example/CardParts.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		80F3C768234ADA7900F5D271 /* CardPartMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F3C767234ADA7900F5D271 /* CardPartMapViewTests.swift */; };
 		9A33961F2410208D00167DD5 /* CardPartsBottomSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A33961E2410208D00167DD5 /* CardPartsBottomSheetTests.swift */; };
 		9A9AE5C323FBA72D0006E1EC /* CardPartBottomSheetCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9AE5C223FBA72D0006E1EC /* CardPartBottomSheetCardController.swift */; };
+		A6A6D2CD272463EE00DA453A /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A6D2CC272463EE00DA453A /* ArrayTests.swift */; };
 		EB16E38A2396E8FD003F70A2 /* CardParthCustomMarginsCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB16E3892396E8FD003F70A2 /* CardParthCustomMarginsCardController.swift */; };
 /* End PBXBuildFile section */
 
@@ -136,6 +137,7 @@
 		80F3C767234ADA7900F5D271 /* CardPartMapViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartMapViewTests.swift; sourceTree = "<group>"; };
 		9A33961E2410208D00167DD5 /* CardPartsBottomSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartsBottomSheetTests.swift; sourceTree = "<group>"; };
 		9A9AE5C223FBA72D0006E1EC /* CardPartBottomSheetCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPartBottomSheetCardController.swift; sourceTree = "<group>"; };
+		A6A6D2CC272463EE00DA453A /* ArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
 		B21177744B384387575CB614 /* Pods-CardParts_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.debug.xcconfig"; path = "Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		E768E0B2422010080EDB1A52 /* Pods-CardParts_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CardParts_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CardParts_Tests/Pods-CardParts_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		EB16E3892396E8FD003F70A2 /* CardParthCustomMarginsCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardParthCustomMarginsCardController.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				A6A6D2C92724500F00DA453A /* Extensions */,
 				61D4706E1FDA709B00F451F0 /* CardPartButtonViewTests.swift */,
 				61D4706A1FDA709B00F451F0 /* CardPartImageViewTests.swift */,
 				9A33961E2410208D00167DD5 /* CardPartsBottomSheetTests.swift */,
@@ -296,6 +299,14 @@
 				411FA9F08E0EF1AF5B1D8EA1 /* Pods_CardParts_Tests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A6A6D2C92724500F00DA453A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A6A6D2CC272463EE00DA453A /* ArrayTests.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		BABC66A8CBE4FFFB18E62FFE /* Pods */ = {
@@ -574,6 +585,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80F3C768234ADA7900F5D271 /* CardPartMapViewTests.swift in Sources */,
+				A6A6D2CD272463EE00DA453A /* ArrayTests.swift in Sources */,
 				61D470751FDA709B00F451F0 /* CardPartButtonViewTests.swift in Sources */,
 				61D470721FDA709B00F451F0 /* CardPartTitleViewTests.swift in Sources */,
 				55AB80CF20B61E1700B5994B /* CardUtilsTests.swift in Sources */,

--- a/Example/Tests/Extensions/ArrayTests.swift
+++ b/Example/Tests/Extensions/ArrayTests.swift
@@ -1,0 +1,35 @@
+//
+//  ArrayTests.swift
+//  CardParts_Tests
+//
+
+import XCTest
+@testable import CardParts
+
+class ArrayExtesionTests: XCTestCase {
+
+    func testSafeValue() {
+        var array: [Int]
+        
+        // when array is empty
+        array = []
+        
+        XCTAssertNil(array.safeValue(at: -1), "Should be nil for negative index")
+        XCTAssertNil(array.safeValue(at: 0), "Should be nil for positive index if array is empty")
+        XCTAssertNil(array.safeValue(at: Int.random(in: 1...100)), "Should be nil for positive index if array is empty")
+        
+        // when array is not empty
+        array = [
+            Int.random(in: 0...100),
+            Int.random(in: 0...100),
+            Int.random(in: 0...100)
+        ]
+        
+        XCTAssertNil(array.safeValue(at: -1), "Should be nil for negative index")
+        XCTAssertNil(array.safeValue(at: array.count), "Should be nil for positive index out of range")
+
+        for index in 0..<array.count {
+            XCTAssertEqual(array.safeValue(at: index), array[index])
+        }
+    }
+}


### PR DESCRIPTION
## Before you make a Pull Request, read the important guidelines:

## Issue Link :link: https://github.com/intuit/CardParts/issues/278
 <ul>
   <li> Is this a bug fix or a feature? </li>
Bug
   <li> Does it break any existing functionality?</li>
No
</ul>

## Goals of this PR :tada:
 <ul>
   <li> Why is the change important? </li>
Array Extension method to retrieve safeValue could crash if index is negative. 

Though it does not pose any issue at present as there is only one occurrence of `safeValue(at:)` usage, in CardPartHistogramView, which does not use a negative index, the extension method would crash if a negative index is used.
https://github.com/intuit/CardParts/blob/27126a702b8011a274d93a6f0ba5cab18d1bab8c/CardParts/src/Classes/Card%20Parts/CardPartHistogramView.swift#L83-L85

   <li> What does this fix? </li>
This PR aims to fix Array's `safeValue(at:)` method behaviour for negative index.
If a negative index is used, the method would not crash with `index out of range` exception and return nil, thereby making it safe to use with any Integer value.

   <li> How far has it been tested? </li>
Added unit test to test the behaviour of Array `safeValue` method for negative, zero, positive index and positive index out of range.

 </ul>
 
## How Has This Been Tested :mag:

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

<ul>
 <li> User Interface Testing </li>
 <li> Application Testing </li>
</ul>

## Test Configuration :space_invader:

<ul>
 <li> Xcode version: </li> 13.0
 <li> Device/Simulator </li> Simulator 
 <li> iOS version || MacOSX version</li> iOS 15.0
</ul>

## Things to check on :dart:


 - [x] My Pull Request code follows the coding standards and styles of the project 
 - [x] I have worked on unit tests and reviewed my code to the best of my ability 
 - [x] I have used comments to make other coders understand my code better 
 - [x] My changes are good to go without any warnings 
 - [x] I have added unit tests both for the happy and sad path 
 - [x] All of my unit tests pass successfully before pushing the PR 
 - [x] I have made sure all dependent downstream changes impacted by my PR are working 

